### PR TITLE
Removed duplicate call of player.start()

### DIFF
--- a/app/src/main/java/com/antest1/gotobrowser/Helpers/MediaPlayerPool.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Helpers/MediaPlayerPool.java
@@ -128,7 +128,6 @@ public class MediaPlayerPool {
         }
 
         players.add(player);
-        player.start();
     }
 
     private void removeOldestTrack() {


### PR DESCRIPTION
Start is already called in playMp3 and shouldn't be a part of this method anyway, not sure if it causes issue #14 but still...