### PR TITLE
Improve KC animation smoothness

### DIFF
--- a/app/src/main/java/com/antest1/gotobrowser/Browser/ResourceProcess.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Browser/ResourceProcess.java
@@ -470,6 +470,12 @@ public class ResourceProcess {
 
             byte[] byteArray = buffer.toByteArray();
             String main_js = patchMainScript(new String(byteArray, StandardCharsets.UTF_8));
+
+            // Inject the main.js file
+            // Change the animations from tick-based to frame-based
+            // It will make all KC animation smoother especially on webview >=68
+            main_js = main_js.replace("createjs.Ticker.TIMEOUT", "createjs.Ticker.RAF");
+
             InputStream is = new ByteArrayInputStream(main_js.getBytes());
             return new WebResourceResponse("application/javascript", "utf-8", is);
         } else {

--- a/app/src/main/java/com/antest1/gotobrowser/Browser/WebViewL.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Browser/WebViewL.java
@@ -7,9 +7,12 @@ import android.content.Context;
 import android.content.res.Configuration;
 import android.os.Build;
 import android.util.AttributeSet;
+import android.view.View;
 import android.webkit.WebView;
 
 public class WebViewL extends WebView {
+    private boolean alwaysVisible = false;
+
     public WebViewL(Context context) {
         super(getFixedContext(context));
     }
@@ -33,5 +36,27 @@ public class WebViewL extends WebView {
 
     public static Context getFixedContext(Context context) {
         return context.createConfigurationContext(new Configuration());
+    }
+
+    /**
+     * Set whether the WebView should ignore invisible state.
+     * WebView will draw new frames even in background if it is in visible state.
+     *
+     * @param alwaysVisible <code>true</code> to ignore invisible state; <code>false</code> is the default behavior
+     */
+    public void setAlwaysVisible(boolean alwaysVisible) {
+        this.alwaysVisible = alwaysVisible;
+    }
+
+    @Override
+    protected void onWindowVisibilityChanged(int visibility) {
+        if (visibility != View.GONE && alwaysVisible) {
+            // Webview only draws new frames when visible
+            // We want our frame-based animations to work even when user switches to another app
+            // So we prevent webview from entering invisible state
+            super.onWindowVisibilityChanged(View.VISIBLE);
+        } else {
+            super.onWindowVisibilityChanged(visibility);
+        }
     }
 }


### PR DESCRIPTION
As mentioned in issue https://github.com/antest1/GotoBrowser/issues/17, the framerate is low in WebView for new hardware.

### Causes of issue
1. WebView messed up the timer tick since some Chromium updates (66?)
2. KC uses a lot of tick-based animations

### The fix
Inject main.js and change the ticker timing mode to frame-based

### Results
On newer hardware (S9+) and newer WebView (v77), the animation looks like 60 fps stable.
On older hardware (A7 2016) and whatever WebView verion (64, 66, 67 tested), it does no improvement(still ~20fps). Chrome is still a lot faster (~50fps).

### Drawback
When the web page is no longer visible (i.e. switching to another foreground app), timer ticker is only slowed down but frame renderer is completely paused. 

Since now all animation is frame-base, they don't move in background. 

I have prepared a workaround method if you plan to keep KC running in background by ignoring the invisibility state. It is you to decide when and how to use it.