### PR TITLE
Remove framerate patch to allow background animation

### DIFF
--- a/app/src/main/java/com/antest1/gotobrowser/Browser/ResourceProcess.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Browser/ResourceProcess.java
@@ -542,11 +542,6 @@ public class ResourceProcess {
             main_js = main_js.replace(_failureCode, _failureCode.concat("GotoBrowser.kcs_axios_error(".concat(_var).concat("['stack']);")));
         }
 
-        // Low Frame Rate Issue
-        main_js = main_js.replaceFirst(
-                "(createjs(?:\\[\\w+\\('\\w+'\\)\\]){2})\\=createjs(?:\\[\\w+\\('\\w+'\\)\\]){2},",
-                "$1=createjs.Ticker.RAF,");
-
         // Prevent Possible Item Purchase Crash
         main_js = main_js.replaceFirst(
                 "function\\((\\w+)\\)\\{(window\\[\\w+\\('\\w+'\\)]\\(\\w+\\('\\w+'\\),\\w+\\[\\w+\\('\\w+'\\)]\\);)",


### PR DESCRIPTION
Revert changes from https://github.com/antest1/GotoBrowser/pull/34

The RAF render mode forces frames draw on each screen refresh and fix the webview framedrop issue. However it pauses all animation when KC is on background.

Since Webview 82, KC no longer drops frame with the default TIMEOUT render mode. 
I think 82+ is popular enough now, so it is pointless to keep the patch.

Removing the patch allows some background animation without the PIP mode and is good for senka players.

Note that the animation may still slow down and even stop in background depending on the CPU resource throttling. (chromium tab is only allocated with 1% CPU time max)