### PR TITLE
Fix a login page crash caused by failed github connection

### DIFF
--- a/app/src/main/java/com/antest1/gotobrowser/Subtitle/KcSubtitleUtils.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Subtitle/KcSubtitleUtils.java
@@ -222,7 +222,7 @@ public class KcSubtitleUtils {
             @Override
             public void onFailure(Call<JsonArray> call, Throwable t) {
                 loadQuoteSizeData(submeta_path);
-                Log.e("GOTO", "quote_size: " + quoteSizeData.size());
+                Log.e("GOTO", "quote_size: " + (quoteSizeData == null ? -1 : quoteSizeData.size()));
             }
         });
 


### PR DESCRIPTION
I accidentally found a root cause of crash that is happening on some devices/network conditions after a fresh install.

Basically after new installation the quote data cannot be loaded and `quoteSizeData` becomes `null` after calling this:
```
    private static boolean loadQuoteSizeData(String filename) {
        quoteSizeData = KcUtils.readJsonObjectFromFile(filename);
        return quoteSizeData != null;
    }
```


When clicked on "Start" button in Goto (init the webview), it tries to load subtitle data from Github but somehow failed*.
It then tries to print log but Null Pointer Exception here by calling `quoteSizeData.size()`
```
            public void onFailure(Call<JsonArray> call, Throwable t) {
                loadQuoteSizeData(submeta_path);
                Log.e("GOTO", "quote_size: " + quoteSizeData.size());
            }
```




*reasons can be:
* Github is sometimes blocked by GFW in Mainland China.
* Also Github supports TLS 1.2 only, where Android 4.4 by default use TLS 1.0 for file download