### PR TITLE
add long-press tool-tips for menu buttons

### DIFF
--- a/app/src/main/res/layout/activity_fullscreen.xml
+++ b/app/src/main/res/layout/activity_fullscreen.xml
@@ -73,7 +73,8 @@
                 android:background="@color/transparent"
                 android:padding="6dp"
                 android:src="@mipmap/refresh"
-                app:srcCompat="@mipmap/refresh" />
+                app:srcCompat="@mipmap/refresh"
+                tooltipText="@string/menu_tooltip_refresh"/>
 
             <ScrollView
                 android:layout_width="wrap_content"
@@ -95,7 +96,7 @@
                         android:padding="6dp"
                         android:src="@mipmap/aspect_ratio"
                         android:visibility="gone"
-                        app:srcCompat="@mipmap/aspect_ratio" />
+                        app:srcCompat="@mipmap/aspect_ratio"/>
 
                     <ImageView
                         android:id="@+id/menu_mute"
@@ -105,7 +106,8 @@
                         android:background="@color/transparent"
                         android:padding="6dp"
                         android:src="@mipmap/mute"
-                        app:srcCompat="@mipmap/mute" />
+                        app:srcCompat="@mipmap/mute"
+                        tooltipText="@string/menu_tooltip_mute"/>
 
                     <ImageView
                         android:id="@+id/menu_camera"
@@ -115,7 +117,8 @@
                         android:background="@color/transparent"
                         android:padding="6dp"
                         android:src="@mipmap/camera"
-                        app:srcCompat="@mipmap/camera" />
+                        app:srcCompat="@mipmap/camera"
+                        tooltipText="@string/menu_tooltip_camera"/>
 
                     <ImageView
                         android:id="@+id/menu_lock"
@@ -125,7 +128,8 @@
                         android:background="@color/transparent"
                         android:padding="6dp"
                         android:src="@mipmap/lock"
-                        app:srcCompat="@mipmap/lock" />
+                        app:srcCompat="@mipmap/lock"
+                        tooltipText="@string/menu_tooltip_lock"/>
 
                     <ImageView
                         android:id="@+id/menu_brighton"
@@ -135,7 +139,8 @@
                         android:background="@color/transparent"
                         android:padding="6dp"
                         android:src="@mipmap/brighton"
-                        app:srcCompat="@mipmap/brighton" />
+                        app:srcCompat="@mipmap/brighton"
+                        tooltipText="@string/menu_tooltip_brighton"/>
 
                     <ImageView
                         android:id="@+id/menu_cc"
@@ -145,7 +150,8 @@
                         android:background="@color/transparent"
                         android:padding="6dp"
                         android:src="@mipmap/caption"
-                        app:srcCompat="@mipmap/caption" />
+                        app:srcCompat="@mipmap/caption"
+                        tooltipText="@string/menu_tooltip_cc"/>
 
                     <ImageView
                         android:id="@+id/menu_logout"
@@ -156,7 +162,8 @@
                         android:padding="6dp"
                         android:src="@mipmap/logout"
                         android:visibility="visible"
-                        app:srcCompat="@mipmap/logout" />
+                        app:srcCompat="@mipmap/logout"
+                        tooltipText="@string/menu_tooltip_logout"/>
                 </LinearLayout>
             </ScrollView>
 

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -58,6 +58,14 @@
     <string name="setting_alter_method">バイパス方式</string>
     <string name="setting_alter_endpoint">エンドポイントサーバー</string>
 
+    <string name="menu_tooltip_refresh">リフレッシュ</string>
+    <string name="menu_tooltip_mute">Mute Audio</string>
+    <string name="menu_tooltip_camera">スクリーンショット</string>
+    <string name="menu_tooltip_lock">Auto-Rotate Lock</string>
+    <string name="menu_tooltip_brighton">常時画面オン</string>
+    <string name="menu_tooltip_cc">ロケール</string>
+    <string name="menu_tooltip_logout">ログアウト</string>
+
     <string name="settings_mod_label">非公式のMOD（自己責任で使ってください）</string>
     <string name="settings_mod_kantai3d_enable">[Beta] 艦隊立体化改修</string>
     <string name="settings_mod_kantai3d_summary">一部の秘書艦に3Dのような視覚効果を追加します。作者：@laplamgor</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -59,6 +59,14 @@
     <string name="setting_alter_method">우회 방식</string>
     <string name="setting_alter_endpoint">Endpoint 서버</string>
 
+    <string name="menu_tooltip_refresh">Refresh</string>
+    <string name="menu_tooltip_mute">Mute Audio</string>
+    <string name="menu_tooltip_camera">Screenshot Mode</string>
+    <string name="menu_tooltip_lock">Auto-Rotate Lock</string>
+    <string name="menu_tooltip_brighton">Screen Always-On</string>
+    <string name="menu_tooltip_cc">Subtitle</string>
+    <string name="menu_tooltip_logout">Logout</string>
+
     <string name="settings_mod_label">서드파티 모드 (자기 책임하에 사용하세요)</string>
     <string name="settings_mod_kantai3d_enable">[Beta] Kantai 3D</string>
     <string name="settings_mod_kantai3d_summary">일부 비서함에 3D 효과 적용. 저자: @laplamgor</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -57,6 +57,14 @@
     <string name="setting_alter_method">绕行方式</string>
     <string name="setting_alter_endpoint">端点服务器</string>
 
+    <string name="menu_tooltip_refresh">刷新页面</string>
+    <string name="menu_tooltip_mute">静音</string>
+    <string name="menu_tooltip_camera">屏幕截图</string>
+    <string name="menu_tooltip_lock">自动旋转锁定</string>
+    <string name="menu_tooltip_brighton">屏幕常亮</string>
+    <string name="menu_tooltip_cc">字幕</string>
+    <string name="menu_tooltip_logout">注销</string>
+
     <string name="settings_mod_label">第三方MOD（自担风险）</string>
     <string name="settings_mod_kantai3d_enable">[Beta] 舰队立体化改修</string>
     <string name="settings_mod_kantai3d_summary">为部份秘书舰添加仿立体的视觉效果。作者：@laplamgor</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -57,6 +57,14 @@
     <string name="setting_alter_method">繞行方式</string>
     <string name="setting_alter_endpoint">端點服務器</string>
 
+    <string name="menu_tooltip_refresh">重新整理頁面</string>
+    <string name="menu_tooltip_mute">靜音</string>
+    <string name="menu_tooltip_camera">熒幕截圖</string>
+    <string name="menu_tooltip_lock">自動旋轉鎖定</string>
+    <string name="menu_tooltip_brighton">熒幕常亮</string>
+    <string name="menu_tooltip_cc">字幕</string>
+    <string name="menu_tooltip_logout">登出</string>
+
     <string name="settings_mod_label">第三方MOD（風險自負）</string>
     <string name="settings_mod_kantai3d_enable">[Beta] 艦隊立體化改修</string>
     <string name="settings_mod_kantai3d_summary">為部份秘書艦添加仿立體的視覺效果。作者：@laplamgor</string>

--- a/app/src/main/res/values-zh-rMO/strings.xml
+++ b/app/src/main/res/values-zh-rMO/strings.xml
@@ -57,6 +57,14 @@
     <string name="setting_alter_method">繞行方式</string>
     <string name="setting_alter_endpoint">端點服務器</string>
 
+    <string name="menu_tooltip_refresh">重新整理頁面</string>
+    <string name="menu_tooltip_mute">靜音</string>
+    <string name="menu_tooltip_camera">熒幕截圖</string>
+    <string name="menu_tooltip_lock">自動旋轉鎖定</string>
+    <string name="menu_tooltip_brighton">熒幕常亮</string>
+    <string name="menu_tooltip_cc">字幕</string>
+    <string name="menu_tooltip_logout">登出</string>
+
     <string name="settings_mod_label">第三方MOD（風險自負）</string>
     <string name="settings_mod_kantai3d_enable">[Beta] 艦隊立體化改修</string>
     <string name="settings_mod_kantai3d_summary">為部份秘書艦添加仿立體的視覺效果。作者：@laplamgor</string>

--- a/app/src/main/res/values-zh-rSG/strings.xml
+++ b/app/src/main/res/values-zh-rSG/strings.xml
@@ -57,6 +57,14 @@
     <string name="setting_alter_method">绕行方式</string>
     <string name="setting_alter_endpoint">端点服务器</string>
 
+    <string name="menu_tooltip_refresh">刷新页面</string>
+    <string name="menu_tooltip_mute">静音</string>
+    <string name="menu_tooltip_camera">屏幕截图</string>
+    <string name="menu_tooltip_lock">自动旋转锁定</string>
+    <string name="menu_tooltip_brighton">屏幕常亮</string>
+    <string name="menu_tooltip_cc">字幕</string>
+    <string name="menu_tooltip_logout">注销</string>
+
     <string name="settings_mod_label">第三方MOD（自担风险）</string>
     <string name="settings_mod_kantai3d_enable">[Beta] 舰队立体化改修</string>
     <string name="settings_mod_kantai3d_summary">为部份秘书舰添加仿立体的视觉效果。作者：@laplamgor</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -57,6 +57,14 @@
     <string name="setting_alter_method">繞行方式</string>
     <string name="setting_alter_endpoint">端點服務器</string>
 
+    <string name="menu_tooltip_refresh">重新整理頁面</string>
+    <string name="menu_tooltip_mute">靜音</string>
+    <string name="menu_tooltip_camera">螢幕截圖</string>
+    <string name="menu_tooltip_lock">自動旋轉鎖定</string>
+    <string name="menu_tooltip_brighton">螢幕常亮</string>
+    <string name="menu_tooltip_cc">字幕</string>
+    <string name="menu_tooltip_logout">登出</string>
+
     <string name="settings_mod_label">第三方MOD（風險自負）</string>
     <string name="settings_mod_kantai3d_enable">[Beta] 艦隊立體化改修</string>
     <string name="settings_mod_kantai3d_summary">為部份秘書艦添加仿立體的視覺效果。作者：@laplamgor</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,6 +68,14 @@
     <string name="setting_alter_method_proxy">KCCacheProxy (remote)</string>
     <string name="setting_alter_endpoint">Endpoint Server</string>
 
+    <string name="menu_tooltip_refresh">Refresh</string>
+    <string name="menu_tooltip_mute">Mute Audio</string>
+    <string name="menu_tooltip_camera">Screenshot Mode</string>
+    <string name="menu_tooltip_lock">Auto-Rotate Lock</string>
+    <string name="menu_tooltip_brighton">Screen Always-On</string>
+    <string name="menu_tooltip_cc">Subtitle</string>
+    <string name="menu_tooltip_logout">Logout</string>
+
     <string name="settings_mod_label">Third Party Mods (use at your own risk)</string>
     <string name="settings_mod_kantai3d_enable">[Beta] Kantai 3D</string>
     <string name="settings_mod_kantai3d_summary">Add 3D-like visual effects to some of your secretaries. Author: @laplamgor</string>


### PR DESCRIPTION
Adding tool-tips for the menu buttons.
Long pressing the button will pop up a text description.
*It only shows on Android 8.0+

TBH these buttons are quite hard to understand for new users.

![image](https://user-images.githubusercontent.com/11514317/117190716-5bef8400-ae12-11eb-9acd-a094b274517d.png)
