### PR TITLE
Add high framerate mod option and Update Kantai3D

### DIFF
--- a/app/src/main/java/com/antest1/gotobrowser/Activity/BrowserActivity.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Activity/BrowserActivity.java
@@ -40,6 +40,7 @@ import com.antest1.gotobrowser.Browser.WebViewL;
 import com.antest1.gotobrowser.Browser.WebViewManager;
 import com.antest1.gotobrowser.BuildConfig;
 import com.antest1.gotobrowser.Helpers.BackPressCloseHandler;
+import com.antest1.gotobrowser.Helpers.FpsPatcher;
 import com.antest1.gotobrowser.Helpers.K3dPatcher;
 import com.antest1.gotobrowser.Helpers.KcUtils;
 import com.antest1.gotobrowser.Notification.ScreenshotNotification;
@@ -82,6 +83,7 @@ public class BrowserActivity extends AppCompatActivity {
     private ScreenshotNotification screenshotNotification;
     GestureDetector mDetector;
     private final K3dPatcher k3dPatcher = new K3dPatcher();
+    private final FpsPatcher fpsPatcher = new FpsPatcher();
 
     private boolean isKcBrowserMode = false;
     private boolean isPanelVisible = false;
@@ -105,6 +107,7 @@ public class BrowserActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         k3dPatcher.prepare(this);
+        fpsPatcher.prepare(this);
 
         Log.e("GOTO", "enter");
         super.onCreate(savedInstanceState);

--- a/app/src/main/java/com/antest1/gotobrowser/Activity/SettingsActivity.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Activity/SettingsActivity.java
@@ -47,6 +47,7 @@ import static com.antest1.gotobrowser.Constants.PREF_APP_VERSION;
 import static com.antest1.gotobrowser.Constants.PREF_CHECK_UPDATE;
 import static com.antest1.gotobrowser.Constants.PREF_DEVTOOLS_DEBUG;
 import static com.antest1.gotobrowser.Constants.PREF_FONT_PREFETCH;
+import static com.antest1.gotobrowser.Constants.PREF_MOD_FPS;
 import static com.antest1.gotobrowser.Constants.PREF_MOD_KANTAI3D;
 import static com.antest1.gotobrowser.Constants.PREF_MULTIWIN_MARGIN;
 import static com.antest1.gotobrowser.Constants.PREF_PANEL_METHOD;
@@ -89,6 +90,7 @@ public class SettingsActivity extends AppCompatActivity {
                 case PREF_DEVTOOLS_DEBUG:
                 case PREF_TP_DISCLAIMED:
                 case PREF_MOD_KANTAI3D:
+                case PREF_MOD_FPS:
                 case PREF_USE_EXTCACHE:
                     editor.putBoolean(key, false);
                     break;

--- a/app/src/main/java/com/antest1/gotobrowser/Browser/ResourceProcess.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Browser/ResourceProcess.java
@@ -12,6 +12,7 @@ import android.webkit.WebResourceResponse;
 import android.widget.TextView;
 
 import com.antest1.gotobrowser.Activity.BrowserActivity;
+import com.antest1.gotobrowser.Helpers.FpsPatcher;
 import com.antest1.gotobrowser.Helpers.K3dPatcher;
 import com.antest1.gotobrowser.Helpers.KcUtils;
 import com.antest1.gotobrowser.Helpers.VersionDatabase;
@@ -518,6 +519,7 @@ public class ResourceProcess {
     private String patchMainScript(String main_js, boolean broadcast_mode) {
 
         main_js = K3dPatcher.patchKantai3d(main_js);
+        main_js = FpsPatcher.patchFps(main_js);
 
         // manage bgm loading strategy with global mute variable for audio focus issue
         if (activity.isMuteMode()) {

--- a/app/src/main/java/com/antest1/gotobrowser/Constants.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Constants.java
@@ -38,6 +38,7 @@ public class Constants {
     public static final String PREF_ALTER_ENDPOINT = "pref_alter_endpoint";
     public static final String PREF_TP_DISCLAIMED = "pref_tp_disclaimed";
     public static final String PREF_MOD_KANTAI3D = "pref_mod_kantai3d";
+    public static final String PREF_MOD_FPS = "pref_mod_fps";
     public static final String PREF_USE_EXTCACHE = "pref_use_extcache";
 
     public static final String[] PREF_SETTINGS = {
@@ -52,6 +53,7 @@ public class Constants {
             PREF_ALTER_ENDPOINT,
             PREF_TP_DISCLAIMED,
             PREF_MOD_KANTAI3D,
+            PREF_MOD_FPS,
             PREF_USE_EXTCACHE
     };
 

--- a/app/src/main/java/com/antest1/gotobrowser/Helpers/FpsPatcher.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Helpers/FpsPatcher.java
@@ -1,0 +1,56 @@
+package com.antest1.gotobrowser.Helpers;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import com.antest1.gotobrowser.R;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.antest1.gotobrowser.Constants.PREF_MOD_FPS;
+
+public class FpsPatcher {
+    private static boolean isPatcherEnabled = false;
+
+    public void prepare(Activity activity) {
+        // Only update the enable status when opening the browser view
+        // Require reopening the browser after switching the MOD on or off
+        SharedPreferences sharedPref = activity.getSharedPreferences(
+                activity.getString(R.string.preference_key), Context.MODE_PRIVATE);
+        isPatcherEnabled = sharedPref.getBoolean(PREF_MOD_FPS, false);
+    }
+
+
+    public static String patchFps(String main_js){
+        if (!isPatcherEnabled) {
+            return main_js;
+        }
+
+        Map<String, String> stringsToReplace = new LinkedHashMap<>();
+
+        // Change the create.js ticker mode from Timer to to RAF
+        stringsToReplace.put(
+                "(createjs(?:\\[\\w+\\('\\w+'\\)\\]){2})\\=createjs(?:\\[\\w+\\('\\w+'\\)\\]){2},",
+                "$1=createjs.Ticker.RAF,");
+
+        String replaced = main_js;
+        for (Map.Entry<String, String> stringToReplace : stringsToReplace.entrySet()) {
+            Pattern pattern = Pattern.compile(stringToReplace.getKey());
+            Matcher matcher = pattern.matcher(replaced);
+            if (matcher.find() && !matcher.find()) {
+                // Find one and only one match
+                matcher.reset();
+                replaced = matcher.replaceFirst(stringToReplace.getValue());
+            } else {
+                // The main.js is probably updated and no longer support the 3D patch currently
+                // Immediately return the unpatched main.js
+                return main_js;
+            }
+        }
+        return replaced;
+    }
+}

--- a/app/src/main/java/com/antest1/gotobrowser/Helpers/K3dPatcher.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Helpers/K3dPatcher.java
@@ -174,7 +174,7 @@ public class K3dPatcher implements SensorEventListener {
                 "window.portOffset = -window.charal + window.charah.x;//-l+h.x\n" +
                 "window.portOffsetR = window.charar;//r\n" +
                 "\n" +
-                "window.displacementSprite = PIXI.Sprite.fromImage('https://kantai3d.com/'+ window.displacementPath );\n" +
+                "window.displacementSprite = PIXI.Sprite.fromImage(window.displacementPath.replace(/resources\\\\/ship\\\\/full[_dmg]*\\\\/([0-9]*)_([0-9_a-z]*).png(\\\\?version=)?([0-9]*)/g, \"https://cdn.jsdelivr.net/gh/laplamgor/kantai3d-depth-maps@master/source/\\$1/\\$1_\\$2_v\\$4\\.png\"));\n" +
                 "\n" +
                 "window.displacementFilter.uniforms.textureWidth = this._chara.texture.width;\n" +
                 "window.displacementFilter.uniforms.textureHeight = this._chara.texture.height;\n" +

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -69,6 +69,9 @@
     <string name="settings_mod_label">非公式のMOD（自己責任で使ってください）</string>
     <string name="settings_mod_kantai3d_enable">[Beta] Kantai3D v1.2</string>
     <string name="settings_mod_kantai3d_summary">一部の秘書艦に3Dのような視覚効果を追加します。作者：@laplamgor</string>
+    <string name="settings_mod_kantai3d_about">About Kantai3D</string>
+    <string name="settings_mod_fps_enable">60FPS制限を削除します</string>
+    <string name="settings_mod_fps_summary">高リフレッシュ・レート対応。ゲームの速度は影響を受けません。</string>
     <string name="settings_use_external_dir">キャッシングに外部ストレージを使用</string>
     <string name="menu_tooltip_kantai3d">3D効果</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -67,7 +67,7 @@
     <string name="menu_tooltip_logout">ログアウト</string>
 
     <string name="settings_mod_label">非公式のMOD（自己責任で使ってください）</string>
-    <string name="settings_mod_kantai3d_enable">[Beta] 艦隊立体化改修</string>
+    <string name="settings_mod_kantai3d_enable">[Beta] Kantai3D v1.2</string>
     <string name="settings_mod_kantai3d_summary">一部の秘書艦に3Dのような視覚効果を追加します。作者：@laplamgor</string>
     <string name="settings_use_external_dir">キャッシングに外部ストレージを使用</string>
     <string name="menu_tooltip_kantai3d">3D効果</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -68,7 +68,7 @@
     <string name="menu_tooltip_logout">Logout</string>
 
     <string name="settings_mod_label">서드파티 모드 (자기 책임하에 사용하세요)</string>
-    <string name="settings_mod_kantai3d_enable">[Beta] Kantai 3D</string>
+    <string name="settings_mod_kantai3d_enable">[Beta] Kantai3D v1.2</string>
     <string name="settings_mod_kantai3d_summary">일부 비서함에 3D 효과 적용. 저자: @laplamgor</string>
     <string name="settings_use_external_dir">리소스 캐싱 시 외부 저장소 사용</string>
     <string name="menu_tooltip_kantai3d">3D 적용</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -70,6 +70,9 @@
     <string name="settings_mod_label">서드파티 모드 (자기 책임하에 사용하세요)</string>
     <string name="settings_mod_kantai3d_enable">[Beta] Kantai3D v1.2</string>
     <string name="settings_mod_kantai3d_summary">일부 비서함에 3D 효과 적용. 저자: @laplamgor</string>
+    <string name="settings_mod_kantai3d_about">About Kantai3D</string>
+    <string name="settings_mod_fps_enable">60FPS 제한 제거</string>
+    <string name="settings_mod_fps_summary">더 높은 재생 빈도 장치를 지원합니다. 애니메이션 속도는 영향을 받지 않습니다.</string>
     <string name="settings_use_external_dir">리소스 캐싱 시 외부 저장소 사용</string>
     <string name="menu_tooltip_kantai3d">3D 적용</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -66,7 +66,7 @@
     <string name="menu_tooltip_logout">注销</string>
 
     <string name="settings_mod_label">第三方MOD（自担风险）</string>
-    <string name="settings_mod_kantai3d_enable">[Beta] 舰队立体化改修</string>
+    <string name="settings_mod_kantai3d_enable">[Beta] Kantai3D v1.2</string>
     <string name="settings_mod_kantai3d_summary">为部份秘书舰添加仿立体的视觉效果。作者：@laplamgor</string>
     <string name="settings_use_external_dir">使用外部存储进行缓存</string>
     <string name="menu_tooltip_kantai3d">开关立体效果</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -68,6 +68,9 @@
     <string name="settings_mod_label">第三方MOD（自担风险）</string>
     <string name="settings_mod_kantai3d_enable">[Beta] Kantai3D v1.2</string>
     <string name="settings_mod_kantai3d_summary">为部份秘书舰添加仿立体的视觉效果。作者：@laplamgor</string>
+    <string name="settings_mod_kantai3d_about">About Kantai3D</string>
+    <string name="settings_mod_fps_enable">移除60帧限制</string>
+    <string name="settings_mod_fps_summary">支持高刷新率手机。游戏速度不会受影响。</string>
     <string name="settings_use_external_dir">使用外部存储进行缓存</string>
     <string name="menu_tooltip_kantai3d">开关立体效果</string>
 </resources>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -66,7 +66,7 @@
     <string name="menu_tooltip_logout">登出</string>
 
     <string name="settings_mod_label">第三方MOD（風險自負）</string>
-    <string name="settings_mod_kantai3d_enable">[Beta] 艦隊立體化改修</string>
+    <string name="settings_mod_kantai3d_enable">[Beta] Kantai3D v1.2</string>
     <string name="settings_mod_kantai3d_summary">為部份秘書艦添加仿立體的視覺效果。作者：@laplamgor</string>
 
     <string name="settings_use_external_dir">使用外部存儲存放快取</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -68,7 +68,9 @@
     <string name="settings_mod_label">第三方MOD（風險自負）</string>
     <string name="settings_mod_kantai3d_enable">[Beta] Kantai3D v1.2</string>
     <string name="settings_mod_kantai3d_summary">為部份秘書艦添加仿立體的視覺效果。作者：@laplamgor</string>
-
+    <string name="settings_mod_kantai3d_about">About Kantai3D</string>
+    <string name="settings_mod_fps_enable">移除60幀限制</string>
+    <string name="settings_mod_fps_summary">支持高刷新率手機。遊戲速度不會受影響。</string>
     <string name="settings_use_external_dir">使用外部存儲存放快取</string>
     <string name="menu_tooltip_kantai3d">開關立體效果</string>
 </resources>

--- a/app/src/main/res/values-zh-rMO/strings.xml
+++ b/app/src/main/res/values-zh-rMO/strings.xml
@@ -66,7 +66,7 @@
     <string name="menu_tooltip_logout">登出</string>
 
     <string name="settings_mod_label">第三方MOD（風險自負）</string>
-    <string name="settings_mod_kantai3d_enable">[Beta] 艦隊立體化改修</string>
+    <string name="settings_mod_kantai3d_enable">[Beta] Kantai3D v1.2</string>
     <string name="settings_mod_kantai3d_summary">為部份秘書艦添加仿立體的視覺效果。作者：@laplamgor</string>
 
     <string name="settings_use_external_dir">使用外部存儲存放快取</string>

--- a/app/src/main/res/values-zh-rMO/strings.xml
+++ b/app/src/main/res/values-zh-rMO/strings.xml
@@ -68,7 +68,9 @@
     <string name="settings_mod_label">第三方MOD（風險自負）</string>
     <string name="settings_mod_kantai3d_enable">[Beta] Kantai3D v1.2</string>
     <string name="settings_mod_kantai3d_summary">為部份秘書艦添加仿立體的視覺效果。作者：@laplamgor</string>
-
+    <string name="settings_mod_kantai3d_about">About Kantai3D</string>
+    <string name="settings_mod_fps_enable">移除60幀限制</string>
+    <string name="settings_mod_fps_summary">支持高刷新率手機。遊戲速度不會受影響。</string>
     <string name="settings_use_external_dir">使用外部存儲存放快取</string>
     <string name="menu_tooltip_kantai3d">開關立體效果</string>
 </resources>

--- a/app/src/main/res/values-zh-rSG/strings.xml
+++ b/app/src/main/res/values-zh-rSG/strings.xml
@@ -66,7 +66,7 @@
     <string name="menu_tooltip_logout">注销</string>
 
     <string name="settings_mod_label">第三方MOD（自担风险）</string>
-    <string name="settings_mod_kantai3d_enable">[Beta] 舰队立体化改修</string>
+    <string name="settings_mod_kantai3d_enable">[Beta] Kantai3D v1.2</string>
     <string name="settings_mod_kantai3d_summary">为部份秘书舰添加仿立体的视觉效果。作者：@laplamgor</string>
     <string name="settings_use_external_dir">使用外部存储进行缓存</string>
     <string name="menu_tooltip_kantai3d">开关立体效果</string>

--- a/app/src/main/res/values-zh-rSG/strings.xml
+++ b/app/src/main/res/values-zh-rSG/strings.xml
@@ -68,6 +68,9 @@
     <string name="settings_mod_label">第三方MOD（自担风险）</string>
     <string name="settings_mod_kantai3d_enable">[Beta] Kantai3D v1.2</string>
     <string name="settings_mod_kantai3d_summary">为部份秘书舰添加仿立体的视觉效果。作者：@laplamgor</string>
+    <string name="settings_mod_kantai3d_about">About Kantai3D</string>
+    <string name="settings_mod_fps_enable">移除60帧限制</string>
+    <string name="settings_mod_fps_summary">支持高刷新率手机。游戏速度不会受影响。</string>
     <string name="settings_use_external_dir">使用外部存储进行缓存</string>
     <string name="menu_tooltip_kantai3d">开关立体效果</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -66,7 +66,7 @@
     <string name="menu_tooltip_logout">登出</string>
 
     <string name="settings_mod_label">第三方MOD（風險自負）</string>
-    <string name="settings_mod_kantai3d_enable">[Beta] 艦隊立體化改修</string>
+    <string name="settings_mod_kantai3d_enable">[Beta] Kantai3D v1.2</string>
     <string name="settings_mod_kantai3d_summary">為部份秘書艦添加仿立體的視覺效果。作者：@laplamgor</string>
     <string name="settings_use_external_dir">使用外部存儲存放緩存</string>
     <string name="menu_tooltip_kantai3d">開關立體效果</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -68,6 +68,9 @@
     <string name="settings_mod_label">第三方MOD（風險自負）</string>
     <string name="settings_mod_kantai3d_enable">[Beta] Kantai3D v1.2</string>
     <string name="settings_mod_kantai3d_summary">為部份秘書艦添加仿立體的視覺效果。作者：@laplamgor</string>
+    <string name="settings_mod_kantai3d_about">About Kantai3D</string>
+    <string name="settings_mod_fps_enable">移除60幀限制</string>
+    <string name="settings_mod_fps_summary">支持高刷新率手機。遊戲速度不會受影響。</string>
     <string name="settings_use_external_dir">使用外部存儲存放緩存</string>
     <string name="menu_tooltip_kantai3d">開關立體效果</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -77,7 +77,7 @@
     <string name="menu_tooltip_logout">Logout</string>
 
     <string name="settings_mod_label">Third Party Mods (use at your own risk)</string>
-    <string name="settings_mod_kantai3d_enable">[Beta] Kantai 3D</string>
+    <string name="settings_mod_kantai3d_enable">[Beta] Kantai3D v1.2</string>
     <string name="settings_mod_kantai3d_summary">Add 3D-like visual effects to some of your secretaries. Author: @laplamgor</string>
     <string name="settings_use_external_dir">Use External Storage for Resource Caching</string>
     <string name="menu_tooltip_kantai3d">Toggle 3D effects</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,6 +79,9 @@
     <string name="settings_mod_label">Third Party Mods (use at your own risk)</string>
     <string name="settings_mod_kantai3d_enable">[Beta] Kantai3D v1.2</string>
     <string name="settings_mod_kantai3d_summary">Add 3D-like visual effects to some of your secretaries. Author: @laplamgor</string>
+    <string name="settings_mod_kantai3d_about">About Kantai3D</string>
+    <string name="settings_mod_fps_enable">Remove 60 FPS limit</string>
+    <string name="settings_mod_fps_summary">Support higher refresh rate devices. Animation speed is not affected.</string>
     <string name="settings_use_external_dir">Use External Storage for Resource Caching</string>
     <string name="menu_tooltip_kantai3d">Toggle 3D effects</string>
 </resources>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -88,11 +88,26 @@
         app:title="@string/settings_mod_label">
 
         <SwitchPreferenceCompat
+            android:summary="@string/settings_mod_fps_summary"
+            app:iconSpaceReserved="false"
+            app:key="pref_mod_fps"
+            app:title="@string/settings_mod_fps_enable" />
+
+        <SwitchPreferenceCompat
             android:summary="@string/settings_mod_kantai3d_summary"
             app:iconSpaceReserved="false"
             app:key="pref_mod_kantai3d"
             app:title="@string/settings_mod_kantai3d_enable" />
 
+        <Preference
+            app:iconSpaceReserved="false"
+            app:key="pref_github2"
+            app:title="@string/settings_mod_kantai3d_about"
+            app:summary="https://github.com/laplamgor/kantai3d">
+            <intent
+                android:action="android.intent.action.VIEW"
+                android:data="https://github.com/laplamgor/kantai3d"/>
+        </Preference>
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
### Remove 60 FPS limit

Kancolle is officially limited to 60 FPS.

A long time ago, this WebView timer issue fix PR https://github.com/antest1/GotoBrowser/pull/34 removed FPS limit as a side effect bonus.

But the fix is removed in https://github.com/antest1/GotoBrowser/pull/51, because in the WebView 82+ timer is no longer throttled.

I just got my first 120Hz phone and can finally verify it.
120 Hz is actually so good and I want to add it back as an option (default is off = 60fps only)

I also tested in map 1-1A to confirm that higher framerate will NOT reduce battle time. So it should not break game balance. But I will still keep it in "dangerous zone"

![image](https://user-images.githubusercontent.com/11514317/128901312-d43db158-151a-44e5-9438-e07a0f33cbd1.png)



### Kantai3D Update

- Change the depth map download source to jsdelivr CDN which is much faster to non-Asia users

- Add an About link

*high FPS and Kantai3D options are not depending on each other.