### PR TITLE
Fix unwanted margin in PIP and free-form mode

### DIFF
--- a/app/src/main/java/com/antest1/gotobrowser/Activity/BrowserActivity.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Activity/BrowserActivity.java
@@ -625,17 +625,24 @@ public class BrowserActivity extends AppCompatActivity {
 
     public void setMultiwindowMargin() {
         ViewGroup.MarginLayoutParams params = (ViewGroup.MarginLayoutParams) mContentView.getLayoutParams();
-        if (isMultiWindowMode()) {
+        if (isMultiWindowMode() && !isInPictureInPictureMode) {
             Rect windowRect = new Rect();
             Rect screenRect = new Rect();
             View decorView = getWindow().getDecorView();
             decorView.getWindowVisibleDisplayFrame(windowRect);
             decorView.getGlobalVisibleRect(screenRect);
 
-            int center = (screenRect.top + screenRect.bottom) / 2;
-            if (windowRect.top > center) params.setMargins(0, 24, 0, 0);
-            else if (windowRect.bottom < center) params.setMargins(0, 0, 0, 24);
-            else params.setMargins(0, 0, 0, 0);
+            // In split screen mode, the window and screen have 1-2 edges aligned
+            if (windowRect.top != screenRect.top && windowRect.bottom != screenRect.bottom &&
+                    windowRect.left != screenRect.left && windowRect.right != screenRect.right) {
+                // it is in free-form mode and should not add black bar
+                params.setMargins(0, 0, 0, 0);
+            }  else {
+                int center = (screenRect.top + screenRect.bottom) / 2;
+                if (windowRect.top > center) params.setMargins(0, 24, 0, 0);
+                else if (windowRect.bottom < center) params.setMargins(0, 0, 0, 24);
+                else params.setMargins(0, 0, 0, 0);
+            }
         } else {
             params.setMargins(0, 0, 0, 0);
         }
@@ -681,6 +688,8 @@ public class BrowserActivity extends AppCompatActivity {
             if (adjust_layout) {
                 isAdjustChangedByUser = true;
             }
+            // Update margin again to undo multi-window black bar
+            setMultiwindowMargin();
         } else {
             mContentView.setZ(0);
         }


### PR DESCRIPTION
The feature "Add Margin from Divider" was applied to PIP mode, or free-form window mode.

The margin should be added only when the user is in split-screen mode.

Here is a fix.

### Before
![image](https://user-images.githubusercontent.com/11514317/128903276-7e7e8986-23f9-4cfc-9c61-2830bd3a0ad9.png)

### After
![image](https://user-images.githubusercontent.com/11514317/128903305-d21a91c8-0557-4f4a-b35e-1a4750a47d72.png)
