### PR TITLE
Retry Options on Asset Download Failure

### DIFF
--- a/app/src/main/java/com/antest1/gotobrowser/Activity/SettingsActivity.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Activity/SettingsActivity.java
@@ -42,6 +42,8 @@ import static com.antest1.gotobrowser.Constants.PREF_MOD_KANTAI3D;
 import static com.antest1.gotobrowser.Constants.PREF_MULTIWIN_MARGIN;
 import static com.antest1.gotobrowser.Constants.PREF_PANEL_METHOD;
 import static com.antest1.gotobrowser.Constants.PREF_PIP_MODE;
+import static com.antest1.gotobrowser.Constants.PREF_RETRY;
+import static com.antest1.gotobrowser.Constants.PREF_RETRY_DEF;
 import static com.antest1.gotobrowser.Constants.PREF_SETTINGS;
 import static com.antest1.gotobrowser.Constants.PREF_SUBTITLE_LOCALE;
 import static com.antest1.gotobrowser.Constants.PREF_SUBTITLE_UPDATE;
@@ -88,6 +90,9 @@ public class SettingsActivity extends AppCompatActivity {
                     break;
                 case PREF_ALTER_ENDPOINT:
                     editor.putString(key, DEFAULT_ALTER_GADGET_URL);
+                    break;
+                case PREF_RETRY:
+                    editor.putBoolean(key, PREF_RETRY_DEF);
                     break;
                 default:
                     editor.putString(key, "");

--- a/app/src/main/java/com/antest1/gotobrowser/Activity/SettingsActivity.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Activity/SettingsActivity.java
@@ -42,8 +42,7 @@ import static com.antest1.gotobrowser.Constants.PREF_MOD_KANTAI3D;
 import static com.antest1.gotobrowser.Constants.PREF_MULTIWIN_MARGIN;
 import static com.antest1.gotobrowser.Constants.PREF_PANEL_METHOD;
 import static com.antest1.gotobrowser.Constants.PREF_PIP_MODE;
-import static com.antest1.gotobrowser.Constants.PREF_RETRY;
-import static com.antest1.gotobrowser.Constants.PREF_RETRY_DEF;
+import static com.antest1.gotobrowser.Constants.PREF_DOWNLOAD_RETRY;
 import static com.antest1.gotobrowser.Constants.PREF_SETTINGS;
 import static com.antest1.gotobrowser.Constants.PREF_SUBTITLE_LOCALE;
 import static com.antest1.gotobrowser.Constants.PREF_SUBTITLE_UPDATE;
@@ -72,6 +71,7 @@ public class SettingsActivity extends AppCompatActivity {
         for (String key: PREF_SETTINGS) {
             if (!sharedPref.contains(key)) switch (key) {
                 case PREF_FONT_PREFETCH:
+                case PREF_DOWNLOAD_RETRY:
                     editor.putBoolean(key, true);
                     break;
                 case PREF_PIP_MODE:
@@ -90,9 +90,6 @@ public class SettingsActivity extends AppCompatActivity {
                     break;
                 case PREF_ALTER_ENDPOINT:
                     editor.putString(key, DEFAULT_ALTER_GADGET_URL);
-                    break;
-                case PREF_RETRY:
-                    editor.putBoolean(key, PREF_RETRY_DEF);
                     break;
                 default:
                     editor.putString(key, "");

--- a/app/src/main/java/com/antest1/gotobrowser/Browser/ResourceProcess.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Browser/ResourceProcess.java
@@ -50,8 +50,7 @@ import static com.antest1.gotobrowser.Constants.PREF_ALTER_METHOD;
 import static com.antest1.gotobrowser.Constants.PREF_ALTER_METHOD_URL;
 import static com.antest1.gotobrowser.Constants.PREF_BROADCAST;
 import static com.antest1.gotobrowser.Constants.PREF_FONT_PREFETCH;
-import static com.antest1.gotobrowser.Constants.PREF_RETRY;
-import static com.antest1.gotobrowser.Constants.PREF_RETRY_DEF;
+import static com.antest1.gotobrowser.Constants.PREF_DOWNLOAD_RETRY;
 import static com.antest1.gotobrowser.Constants.PREF_SUBTITLE_LOCALE;
 import static com.antest1.gotobrowser.Constants.REQUEST_BLOCK_RULES;
 import static com.antest1.gotobrowser.Constants.VERSION_TABLE_VERSION;
@@ -329,7 +328,7 @@ public class ResourceProcess {
     }
 
     private WebResourceResponse promptForRetry(JsonObject file_info, JsonObject update_info, int resource_type) {
-        boolean isRetryPromptEnabled = sharedPref.getBoolean(PREF_RETRY, PREF_RETRY_DEF);
+        boolean isRetryPromptEnabled = sharedPref.getBoolean(PREF_DOWNLOAD_RETRY, true);
         if (!isRetryPromptEnabled) {
             return null;
         }
@@ -354,7 +353,7 @@ public class ResourceProcess {
                     case DialogInterface.BUTTON_NEGATIVE: // no and never ask again
                         // User give up and it is ok to stop loading
                         // And change preference to never ask again
-                        sharedPref.edit().putBoolean(PREF_RETRY, false).apply();
+                        sharedPref.edit().putBoolean(PREF_DOWNLOAD_RETRY, false).apply();
                         cancelled.set(true);
                         retryReady.countDown();
                 }

--- a/app/src/main/java/com/antest1/gotobrowser/Constants.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Constants.java
@@ -39,6 +39,8 @@ public class Constants {
     public static final String PREF_MOD_FPS = "pref_mod_fps";
     public static final String PREF_USE_EXTCACHE = "pref_use_extcache";
     public static final String PREF_UI_HELP_CHECKED = "pref_ui_help_checked";
+    public static final String PREF_RETRY = "pref_retry";
+    public static final boolean PREF_RETRY_DEF = false;
 
     public static final String[] PREF_SETTINGS = {
             PREF_FONT_PREFETCH,
@@ -50,6 +52,7 @@ public class Constants {
             PREF_DEVTOOLS_DEBUG,
             PREF_ALTER_METHOD,
             PREF_ALTER_ENDPOINT,
+            PREF_RETRY,
             PREF_TP_DISCLAIMED,
             PREF_MOD_KANTAI3D,
             PREF_MOD_FPS,

--- a/app/src/main/java/com/antest1/gotobrowser/Constants.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Constants.java
@@ -39,8 +39,7 @@ public class Constants {
     public static final String PREF_MOD_FPS = "pref_mod_fps";
     public static final String PREF_USE_EXTCACHE = "pref_use_extcache";
     public static final String PREF_UI_HELP_CHECKED = "pref_ui_help_checked";
-    public static final String PREF_RETRY = "pref_retry";
-    public static final boolean PREF_RETRY_DEF = false;
+    public static final String PREF_DOWNLOAD_RETRY = "pref_retry";
 
     public static final String[] PREF_SETTINGS = {
             PREF_FONT_PREFETCH,
@@ -52,7 +51,7 @@ public class Constants {
             PREF_DEVTOOLS_DEBUG,
             PREF_ALTER_METHOD,
             PREF_ALTER_ENDPOINT,
-            PREF_RETRY,
+            PREF_DOWNLOAD_RETRY,
             PREF_TP_DISCLAIMED,
             PREF_MOD_KANTAI3D,
             PREF_MOD_FPS,

--- a/app/src/main/java/com/antest1/gotobrowser/Subtitle/Kc3SubtitleProvider.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Subtitle/Kc3SubtitleProvider.java
@@ -323,7 +323,7 @@ public class Kc3SubtitleProvider implements SubtitleProvider {
     }
 
 
-    public SubtitleData getSubtitleData(String url, String path, String voiceSize) throws ParseException {
+    public SubtitleData getSubtitleData(String url, String path, String voiceSize) {
         SubtitleData data = null;
         if (url.contains("/kcs/sound/kc")) {
             String info = path.replace("/kcs/sound/kc", "").replace(".mp3", "");
@@ -347,8 +347,13 @@ public class Kc3SubtitleProvider implements SubtitleProvider {
                 Date now = new Date();
                 String voiceLineTime = String.format(Locale.US, "%02d:00:00", voiceLineValue - 30);
                 @SuppressLint("SimpleDateFormat") SimpleDateFormat time_fmt = new SimpleDateFormat("HH:mm:ss");
-                Date time_src = time_fmt.parse(time_fmt.format(now));
-                Date time_tgt = time_fmt.parse(voiceLineTime);
+                Date time_src, time_tgt;
+                try {
+                    time_src = time_fmt.parse(time_fmt.format(now));
+                    time_tgt = time_fmt.parse(voiceLineTime);
+                } catch (ParseException e) {
+                    return null;
+                }
                 long diffMsec = time_tgt.getTime() - time_src.getTime();
                 if (voiceLineValue == 30) diffMsec += 86400000;
 

--- a/app/src/main/java/com/antest1/gotobrowser/Subtitle/KcwikiSubtitleProvider.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Subtitle/KcwikiSubtitleProvider.java
@@ -178,7 +178,7 @@ public class KcwikiSubtitleProvider implements SubtitleProvider  {
         return 2000 + 250 * data.length();
     }
 
-    public SubtitleData getSubtitleData(String url, String path, String voiceSize) throws ParseException {
+    public SubtitleData getSubtitleData(String url, String path, String voiceSize) {
         SubtitleData data = null;
         if (url.contains("/kcs/sound/kc")) {
             String info = path.replace("/kcs/sound/kc", "").replace(".mp3", "");
@@ -202,8 +202,13 @@ public class KcwikiSubtitleProvider implements SubtitleProvider  {
                 Date now = new Date();
                 String voiceLineTime = String.format(Locale.US, "%02d:00:00", voiceLineValue - 30);
                 @SuppressLint("SimpleDateFormat") SimpleDateFormat time_fmt = new SimpleDateFormat("HH:mm:ss");
-                Date time_src = time_fmt.parse(time_fmt.format(now));
-                Date time_tgt = time_fmt.parse(voiceLineTime);
+                Date time_src, time_tgt;
+                try {
+                    time_src = time_fmt.parse(time_fmt.format(now));
+                    time_tgt = time_fmt.parse(voiceLineTime);
+                } catch (ParseException e) {
+                    return null;
+                }
                 long diffMsec = time_tgt.getTime() - time_src.getTime();
                 if (voiceLineValue == 30) diffMsec += 86400000;
 

--- a/app/src/main/java/com/antest1/gotobrowser/Subtitle/SubtitleProvider.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Subtitle/SubtitleProvider.java
@@ -8,7 +8,6 @@ import com.antest1.gotobrowser.Activity.SettingsActivity;
 import com.antest1.gotobrowser.Helpers.VersionDatabase;
 import com.google.gson.JsonObject;
 
-import java.text.ParseException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -18,7 +17,7 @@ public interface SubtitleProvider {
 
     boolean loadQuoteData(Context context, String localeCode);
 
-    SubtitleData getSubtitleData(String url, String path, String voiceSize) throws ParseException;
+    SubtitleData getSubtitleData(String url, String path, String voiceSize);
 
     void checkUpdateFromPreference(SettingsActivity.SettingsFragment fragment, String localeCode, Preference subtitleUpdate, VersionDatabase versionTable);
 

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -76,4 +76,11 @@
     <string name="menu_tooltip_kantai3d">3D効果</string>
 
     <string name="browser_ui_hint_text">« 外側をクリックしてパネルを開く »</string>
+    <string name="settings_retry_enable">ゲームアセットのダウンロードの再試行</string>
+    <string name="settings_retry_summary">"ゲーム内のサウンドまたは画像アセットのダウンロードに失敗した場合は、再試行オプションを提供するダイアログボックスがポップアップ表示されます。それは不安定なネットワーク環境によって引き起こされるいくつかの猫を避けることができます。 ゲームデータAPIには適用されません。 "</string>
+    <string name="dialog_retry_title">ゲームアセットのダウンロードに失敗しました</string>
+    <string name="dialog_retry_yes">ダウンロードを再試行し</string>
+    <string name="dialog_retry_no">何もしない</string>
+    <string name="dialog_retry_never">何もしない，二度と聞かないでください</string>
+    <string name="dialog_retry_message">ゲームクライアントがアセットファイルをダウンロードすると、ネットワークの問題が発生します。\nダウンロードを再試行しますか？\n%s</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -78,11 +78,11 @@
 
     <string name="browser_ui_hint_text">« 게임 화면 외의 공간을 눌러 패널을 여세요 »</string>
 
-    <string name="settings_retry_enable">게임 자산 다운로드 재시도</string>
-    <string name="settings_retry_summary">"ゲーム内のサウンドまたは画像アセットのダウンロードに失敗した場合は、再試行オプションを提供するダイアログボックスがポップアップ表示されます。それは不安定なネットワーク環境によって引き起こされるいくつかの猫を避けることができます。 ゲームデータAPIには適用されません。 "</string>
-    <string name="dialog_retry_title">게임 자산 파일을 다운로드하지 못했습니다</string>
+    <string name="settings_retry_enable">게임 에셋 다운로드 재시도</string>
+    <string name="settings_retry_summary">"게임 내의 사운드 혹은 이미지 에셋의 다운로드에 실패한 경우, 다시 다운받을 수 있는 다이얼로그가 표시됩니다. 불안정한 네트워크 환경에 의해 발생하는 에러코 문제를 해결할 수 있습니다. 게임 데이터의 API에는 적용되지 않습니다."</string>
+    <string name="dialog_retry_title">게임 에셋 파일을 다운로드하지 못했습니다</string>
     <string name="dialog_retry_yes">다운로드 다시 시도</string>
-    <string name="dialog_retry_no">아무것도 하지</string>
-    <string name="dialog_retry_never">아무것도 안 해.그만 물어보세요.</string>
-    <string name="dialog_retry_message">게임 클라이언트가 리소스 파일을 다운로드할 때 네트워크 문제가 발생합니다. \n다운로드를 다시 시도하시겠습니까?\n%s</string>
+    <string name="dialog_retry_no">아무것도 하지 않음</string>
+    <string name="dialog_retry_never">다시 물어보지 않음</string>
+    <string name="dialog_retry_message">게임 클라이언트에서 리소스 파일을 다운로드하는 중 네트워크 문제가 발생합니다. \n다운로드를 다시 시도하시겠습니까?\n%s</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -77,4 +77,12 @@
     <string name="menu_tooltip_kantai3d">3D 적용</string>
 
     <string name="browser_ui_hint_text">« 게임 화면 외의 공간을 눌러 패널을 여세요 »</string>
+
+    <string name="settings_retry_enable">게임 자산 다운로드 재시도</string>
+    <string name="settings_retry_summary">"ゲーム内のサウンドまたは画像アセットのダウンロードに失敗した場合は、再試行オプションを提供するダイアログボックスがポップアップ表示されます。それは不安定なネットワーク環境によって引き起こされるいくつかの猫を避けることができます。 ゲームデータAPIには適用されません。 "</string>
+    <string name="dialog_retry_title">게임 자산 파일을 다운로드하지 못했습니다</string>
+    <string name="dialog_retry_yes">다운로드 다시 시도</string>
+    <string name="dialog_retry_no">아무것도 하지</string>
+    <string name="dialog_retry_never">아무것도 안 해.그만 물어보세요.</string>
+    <string name="dialog_retry_message">게임 클라이언트가 리소스 파일을 다운로드할 때 네트워크 문제가 발생합니다. \n다운로드를 다시 시도하시겠습니까?\n%s</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -75,4 +75,12 @@
     <string name="menu_tooltip_kantai3d">开关立体效果</string>
 
     <string name="browser_ui_hint_text">« 点击外侧任意位置以打开面板 »</string>
+
+    <string name="settings_retry_enable">重试游戏数据下载</string>
+    <string name="settings_retry_summary">下载任何游戏内声音或图像失败时提示对话框要求重试。有时避免网络不好导致的猫。不适用于游戏数据API。</string>
+    <string name="dialog_retry_title">下载游戏文件失败</string>
+    <string name="dialog_retry_yes">重试下载</string>
+    <string name="dialog_retry_no">什么也不做</string>
+    <string name="dialog_retry_never">什么也不做，不要再询问</string>
+    <string name="dialog_retry_message">游戏客户端下载资源文件时出现网络问题。\n要重试下载吗？\n%s</string>
 </resources>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -75,4 +75,12 @@
     <string name="menu_tooltip_kantai3d">開關立體效果</string>
 
     <string name="browser_ui_hint_text">« 點擊外側任意位置以打開面板 »</string>
+
+    <string name="settings_retry_enable">重試遊戲資源下載</string>
+    <string name="settings_retry_summary">下載任何遊戲內聲音或圖像失敗時提示對話框要求重試。有時避免網絡不好導致的貓。不適用於遊戲數據API。</string>
+    <string name="dialog_retry_title">下載遊戲檔案失敗</string>
+    <string name="dialog_retry_yes">重試下載</string>
+    <string name="dialog_retry_no">甚麼也不做</string>
+    <string name="dialog_retry_never">甚麼也不做，不要再詢問</string>
+    <string name="dialog_retry_message">遊戲客戶端下載資源文件時出現網絡問題。\n重試下載嗎\n%s</string>
 </resources>

--- a/app/src/main/res/values-zh-rMO/strings.xml
+++ b/app/src/main/res/values-zh-rMO/strings.xml
@@ -75,4 +75,12 @@
     <string name="menu_tooltip_kantai3d">開關立體效果</string>
 
     <string name="browser_ui_hint_text">« 點擊外側任意位置以打開面板 »</string>
+
+    <string name="settings_retry_enable">重試遊戲資源下載</string>
+    <string name="settings_retry_summary">下載任何遊戲內聲音或圖像失敗時提示對話框要求重試。有時避免網絡不好導致的貓。不適用於遊戲數據API。</string>
+    <string name="dialog_retry_title">下載遊戲檔案失敗</string>
+    <string name="dialog_retry_yes">重試下載</string>
+    <string name="dialog_retry_no">甚麼也不做</string>
+    <string name="dialog_retry_never">甚麼也不做，不要再詢問</string>
+    <string name="dialog_retry_message">遊戲客戶端下載資源文件時出現網絡問題。\n重試下載嗎\n%s</string>
 </resources>

--- a/app/src/main/res/values-zh-rSG/strings.xml
+++ b/app/src/main/res/values-zh-rSG/strings.xml
@@ -75,4 +75,12 @@
     <string name="menu_tooltip_kantai3d">开关立体效果</string>
 
     <string name="browser_ui_hint_text">« 点击外侧任意位置以打开面板 »</string>
+
+    <string name="settings_retry_enable">重试游戏数据下载</string>
+    <string name="settings_retry_summary">下载任何游戏内声音或图像失败时提示对话框要求重试。有时避免网络不好导致的猫。不适用于游戏数据API。</string>
+    <string name="dialog_retry_title">下载游戏文件失败</string>
+    <string name="dialog_retry_yes">重试下载</string>
+    <string name="dialog_retry_no">什么也不做</string>
+    <string name="dialog_retry_never">什么也不做，不要再询问</string>
+    <string name="dialog_retry_message">游戏客户端下载资源文件时出现网络问题。\n要重试下载吗？\n%s</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -75,4 +75,12 @@
     <string name="menu_tooltip_kantai3d">開關立體效果</string>
 
     <string name="browser_ui_hint_text">« 點擊外側任意位置以打開面板 »</string>
+
+    <string name="settings_retry_enable">重試遊戲資源下載</string>
+    <string name="settings_retry_summary">下載任何遊戲內聲音或圖像失敗時提示對話框要求重試。有時避免網絡不好導致的貓。不適用於遊戲數據API。</string>
+    <string name="dialog_retry_title">下載遊戲檔案失敗</string>
+    <string name="dialog_retry_yes">重試下載</string>
+    <string name="dialog_retry_no">甚麼也不做</string>
+    <string name="dialog_retry_never">甚麼也不做，不要再詢問</string>
+    <string name="dialog_retry_message">遊戲客戶端下載資源文件時出現網絡問題。\n重試下載嗎\n%s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -86,4 +86,12 @@
     <string name="menu_tooltip_kantai3d">Toggle 3D effects</string>
 
     <string name="browser_ui_hint_text">« click any outside area to open the panel »</string>
+
+    <string name="settings_retry_enable">Retry Option for Resource Download</string>
+    <string name="settings_retry_summary">Prompt a dialog to ask for retry when failed to download any static in-game sound or image resource file. Sometimes avoid cats caused by poor network. DO NOT apply to gameplay data API.</string>
+    <string name="dialog_retry_title">Failed to download a game resource file</string>
+    <string name="dialog_retry_yes">Retry the download</string>
+    <string name="dialog_retry_no">Do nothing</string>
+    <string name="dialog_retry_never">Do nothing and never ask again</string>
+    <string name="dialog_retry_message">A network issue occurs when game client downloads a resource file.\nDo you want to retry the download?\n%s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,9 +87,9 @@
 
     <string name="browser_ui_hint_text">« click any outside area to open the panel »</string>
 
-    <string name="settings_retry_enable">Retry Option for Resource Download</string>
-    <string name="settings_retry_summary">Prompt a dialog to ask for retry when failed to download any static in-game sound or image resource file. Sometimes avoid cats caused by poor network. DO NOT apply to gameplay data API.</string>
-    <string name="dialog_retry_title">Failed to download a game resource file</string>
+    <string name="settings_retry_enable">Retry Game Asset Download</string>
+    <string name="settings_retry_summary">Prompt a dialog to ask for retry when failed to download any in-game sound or image asset. Sometimes avoid cats caused by poor network. DO NOT apply to gameplay data API.</string>
+    <string name="dialog_retry_title">Failed to download a game asset file</string>
     <string name="dialog_retry_yes">Retry the download</string>
     <string name="dialog_retry_no">Do nothing</string>
     <string name="dialog_retry_never">Do nothing and never ask again</string>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -63,6 +63,11 @@
             android:dependency="pref_alter_gadget"
             android:title="@string/setting_alter_endpoint" />
 
+        <SwitchPreferenceCompat
+            android:summary="@string/settings_retry_summary"
+            app:iconSpaceReserved="false"
+            app:key="pref_retry"
+            app:title="@string/settings_retry_enable" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
Basic
--
Failing to download an asset file is one of the reasons of blacked-out texture, missing audio, game freeze or (some) CAT issues under unstable network. 

Therefore I added a handling for asset download failure.

When a static game asset file download request failed, an alert prompt will pop up.
Game webview will paused (UI thread blocked) and 3 options are given:
* retry download
  * gotobrowser will resend the download request to game server. 
    if successful, game will continue like it didn't see an error
    if failed again, the same alert prompt will pop up again, letting user to choose again.
* do nothing
  * when choosing this option, the game will behave exactly like previous version of gotobrowser
    failing to download an asset file may cause blacked-out texture, missing audio, game freeze or (normal) CAT in-game. 
* do nothing, and never ask again
  * same as second option, and also update the user preference setting

---

Definition of **static game asset files**:
* image (.png file)
* texture sprite sheet (.json file)
* audio 

Retry logic DOES NOT apply to game API call, JS file

---

Alert UI:
![image](https://user-images.githubusercontent.com/11514317/143885980-e5f32eea-cb43-44e3-9371-6987f586ab52.png)





Setting
--
The prompt alert is disabled by default currently. But I prefer making it enabled by default.
Because user who doesn't like it can disable the alert (option 3) on the first time it shows up, anyway.

Setting page:
![image](https://user-images.githubusercontent.com/11514317/143888302-a6d0140b-d215-4013-9dfc-86b984ca58ec.png)



TODO
--
* Korean translation
* decide if this alert should be shown by default