### PR TITLE
Compatibility Mode / Force PixiJS to use Canvas Renderer

### DIFF
--- a/app/src/main/java/com/antest1/gotobrowser/Activity/BrowserActivity.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Activity/BrowserActivity.java
@@ -56,7 +56,6 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import static com.antest1.gotobrowser.Browser.WebViewManager.OPEN_KANCOLLE;
 import static com.antest1.gotobrowser.Constants.ACTION_SHOWKEYBOARD;
-import static com.antest1.gotobrowser.Constants.ACTION_SHOWPANEL;
 import static com.antest1.gotobrowser.Constants.APP_UI_HELP_VER;
 import static com.antest1.gotobrowser.Constants.PREF_ADJUSTMENT;
 import static com.antest1.gotobrowser.Constants.PREF_CAPTURE;
@@ -134,7 +133,7 @@ public class BrowserActivity extends AppCompatActivity {
             mContentView.addJavascriptInterface(k3dPatcher,"gyroData");
 
 
-            manager.setHardwardAcceleratedFlag();
+            manager.setHardwareAcceleratedFlag();
 
             // panel, keyboard settings
             initPanelKeyboardFromIntent(getIntent());
@@ -218,7 +217,7 @@ public class BrowserActivity extends AppCompatActivity {
 
             boolean useDevTools = sharedPref.getBoolean(PREF_DEVTOOLS_DEBUG, false);
             if (connector_info != null && connector_info.size() == 2) {
-                WebViewManager.setWebViewSettings(mContentView);
+                manager.setWebViewSettings(mContentView);
                 WebViewManager.enableBrowserCookie(mContentView);
                 WebViewManager.setWebViewDebugging(useDevTools);
                 manager.setWebViewClient(this, mContentView, connector_info);

--- a/app/src/main/java/com/antest1/gotobrowser/Activity/SettingsActivity.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Activity/SettingsActivity.java
@@ -37,6 +37,7 @@ import static com.antest1.gotobrowser.Constants.PREF_APP_VERSION;
 import static com.antest1.gotobrowser.Constants.PREF_CHECK_UPDATE;
 import static com.antest1.gotobrowser.Constants.PREF_DEVTOOLS_DEBUG;
 import static com.antest1.gotobrowser.Constants.PREF_FONT_PREFETCH;
+import static com.antest1.gotobrowser.Constants.PREF_LEGACY_RENDERER;
 import static com.antest1.gotobrowser.Constants.PREF_MOD_FPS;
 import static com.antest1.gotobrowser.Constants.PREF_MOD_KANTAI3D;
 import static com.antest1.gotobrowser.Constants.PREF_MULTIWIN_MARGIN;
@@ -80,6 +81,7 @@ public class SettingsActivity extends AppCompatActivity {
                 case PREF_MOD_KANTAI3D:
                 case PREF_MOD_FPS:
                 case PREF_USE_EXTCACHE:
+                case PREF_LEGACY_RENDERER:
                     editor.putBoolean(key, false);
                     break;
                 case PREF_ALTER_METHOD:

--- a/app/src/main/java/com/antest1/gotobrowser/Activity/SettingsActivity.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Activity/SettingsActivity.java
@@ -138,6 +138,7 @@ public class SettingsActivity extends AppCompatActivity {
                 preference.setOnPreferenceChangeListener(this);
             }
             updateSubtitleDescriptionText();
+            updateKantai3dDisable();
         }
 
         @Override
@@ -188,6 +189,9 @@ public class SettingsActivity extends AppCompatActivity {
                 if (key.equals(PREF_USE_EXTCACHE)) {
                     updateSubtitleDescriptionText();
                 }
+                if (key.equals(PREF_LEGACY_RENDERER)) {
+                    updateKantai3dDisable();
+                }
             }
             return true;
         }
@@ -200,6 +204,14 @@ public class SettingsActivity extends AppCompatActivity {
                 findPreference(PREF_SUBTITLE_UPDATE).setEnabled(false);
                 findPreference(PREF_SUBTITLE_UPDATE).setSummary(getString(R.string.subtitle_select_language));
             }
+        }
+
+
+        private void updateKantai3dDisable() {
+            // Kantai3D only works with WebGL renderer
+            // Gray out the option when legacy renderer is chosen
+            boolean isWebglEnabled = !sharedPref.getBoolean(PREF_LEGACY_RENDERER, false);
+            findPreference(PREF_MOD_KANTAI3D).setEnabled(isWebglEnabled);
         }
 
         private void setSubtitlePreference(String subtitleLocaleCode) {

--- a/app/src/main/java/com/antest1/gotobrowser/Constants.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Constants.java
@@ -35,6 +35,7 @@ public class Constants {
     public static final String PREF_ALTER_METHOD = "pref_alter_method";
     public static final String PREF_ALTER_ENDPOINT = "pref_alter_endpoint";
     public static final String PREF_TP_DISCLAIMED = "pref_tp_disclaimed";
+    public static final String PREF_LEGACY_RENDERER = "pref_legacy_renderer";
     public static final String PREF_MOD_KANTAI3D = "pref_mod_kantai3d";
     public static final String PREF_MOD_FPS = "pref_mod_fps";
     public static final String PREF_USE_EXTCACHE = "pref_use_extcache";
@@ -51,6 +52,7 @@ public class Constants {
             PREF_ALTER_METHOD,
             PREF_ALTER_ENDPOINT,
             PREF_TP_DISCLAIMED,
+            PREF_LEGACY_RENDERER,
             PREF_MOD_KANTAI3D,
             PREF_MOD_FPS,
             PREF_USE_EXTCACHE

--- a/app/src/main/java/com/antest1/gotobrowser/Helpers/K3dPatcher.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Helpers/K3dPatcher.java
@@ -22,6 +22,7 @@ import static android.view.Surface.ROTATION_0;
 import static android.view.Surface.ROTATION_180;
 import static android.view.Surface.ROTATION_270;
 import static android.view.Surface.ROTATION_90;
+import static com.antest1.gotobrowser.Constants.PREF_LEGACY_RENDERER;
 import static com.antest1.gotobrowser.Constants.PREF_MOD_KANTAI3D;
 
 public class K3dPatcher implements SensorEventListener {
@@ -89,7 +90,10 @@ public class K3dPatcher implements SensorEventListener {
         // Require reopening the browser after switching the MOD on or off
         SharedPreferences sharedPref = activity.getSharedPreferences(
                 activity.getString(R.string.preference_key), Context.MODE_PRIVATE);
-        isPatcherEnabled = sharedPref.getBoolean(PREF_MOD_KANTAI3D, false);
+
+        // Kantai3D is disabled if using a legacy renderer
+        isPatcherEnabled = sharedPref.getBoolean(PREF_MOD_KANTAI3D, false) &&
+                !sharedPref.getBoolean(PREF_LEGACY_RENDERER, false);
 
         if (isPatcherEnabled) {
             this.activity = activity;

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -66,6 +66,9 @@
     <string name="menu_tooltip_cc">ロケール</string>
     <string name="menu_tooltip_logout">ログアウト</string>
 
+    <string name="settings_legacy_renderer_summary">PixiJSゲームエンジンにWebGLレンダラーの代わりにCanvasレンダラーを使用するように強制します。 ほとんどのディスプレイの不具合は解決する可能性がありますが、パフォーマンスは低下します。</string>
+    <string name="settings_legacy_renderer_enable">レガシーレンダラを使用する</string>
+
     <string name="settings_mod_label">非公式のMOD（自己責任で使ってください）</string>
     <string name="settings_mod_kantai3d_enable">[Beta] Kantai3D v2.0</string>
     <string name="settings_mod_kantai3d_summary">一部の秘書艦に3Dのような視覚効果とおける乳揺れを追加します。作者：@laplamgor</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -67,6 +67,9 @@
     <string name="menu_tooltip_cc">자막</string>
     <string name="menu_tooltip_logout">로그아웃</string>
 
+    <string name="settings_legacy_renderer_summary">PixiJS 엔진에 WebGL 렌더링 대신 Canvas 렌더링을 사용하도록 강요합니다.대부분의 도형의 이상한 오류를 해결할 수 있지만 효능을 떨어뜨릴 수 있다.</string>
+    <string name="settings_legacy_renderer_enable">레거시 렌더러 사용</string>
+
     <string name="settings_mod_label">서드파티 모드 (자기 책임하에 사용하세요)</string>
     <string name="settings_mod_kantai3d_enable">[Beta] Kantai3D v2.0</string>
     <string name="settings_mod_kantai3d_summary">일부 비서함에 3D 효과 적용. 저자: @laplamgor</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -65,6 +65,9 @@
     <string name="menu_tooltip_cc">字幕</string>
     <string name="menu_tooltip_logout">注销</string>
 
+    <string name="settings_legacy_renderer_enable">改用舊式渲染器</string>
+    <string name="settings_legacy_renderer_summary">强制PixiJS引擎使用Canvas渲染器而非WebGL渲染器。可解决大部份图形奇怪错误但会降低效能。</string>
+
     <string name="settings_mod_label">第三方MOD（自担风险）</string>
     <string name="settings_mod_kantai3d_enable">[Beta] Kantai3D v2.0</string>
     <string name="settings_mod_kantai3d_summary">为部份秘书舰添加仿立体的视觉效果及胸部物理。作者：@laplamgor</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -65,6 +65,9 @@
     <string name="menu_tooltip_cc">字幕</string>
     <string name="menu_tooltip_logout">登出</string>
 
+    <string name="settings_legacy_renderer_enable">改用舊式渲染器</string>
+    <string name="settings_legacy_renderer_summary">強制PixiJS引擎使用Canvas渲染器而非WebGL渲染器。可解決大部份圖形奇怪錯誤但會降低效能。</string>
+
     <string name="settings_mod_label">第三方MOD（風險自負）</string>
     <string name="settings_mod_kantai3d_enable">[Beta] Kantai3D v2.0</string>
     <string name="settings_mod_kantai3d_summary">為部份秘書艦添加仿立體的視覺效果及胸部物理。作者：@laplamgor</string>

--- a/app/src/main/res/values-zh-rMO/strings.xml
+++ b/app/src/main/res/values-zh-rMO/strings.xml
@@ -65,6 +65,9 @@
     <string name="menu_tooltip_cc">字幕</string>
     <string name="menu_tooltip_logout">登出</string>
 
+    <string name="settings_legacy_renderer_enable">改用舊式渲染器</string>
+    <string name="settings_legacy_renderer_summary">強制PixiJS引擎使用Canvas渲染器而非WebGL渲染器。可解決大部份圖形奇怪錯誤但會降低效能。</string>
+
     <string name="settings_mod_label">第三方MOD（風險自負）</string>
     <string name="settings_mod_kantai3d_enable">[Beta] Kantai3D v2.0</string>
     <string name="settings_mod_kantai3d_summary">為部份秘書艦添加仿立體的視覺效果及胸部物理。作者：@laplamgor</string>

--- a/app/src/main/res/values-zh-rSG/strings.xml
+++ b/app/src/main/res/values-zh-rSG/strings.xml
@@ -65,6 +65,9 @@
     <string name="menu_tooltip_cc">字幕</string>
     <string name="menu_tooltip_logout">注销</string>
 
+    <string name="settings_legacy_renderer_enable">改用舊式渲染器</string>
+    <string name="settings_legacy_renderer_summary">强制PixiJS引擎使用Canvas渲染器而非WebGL渲染器。可解决大部份图形奇怪错误但会降低效能。</string>
+
     <string name="settings_mod_label">第三方MOD（自担风险）</string>
     <string name="settings_mod_kantai3d_enable">[Beta] Kantai3D v2.0</string>
     <string name="settings_mod_kantai3d_summary">为部份秘书舰添加仿立体的视觉效果及胸部物理。作者：@laplamgor</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -65,6 +65,9 @@
     <string name="menu_tooltip_cc">字幕</string>
     <string name="menu_tooltip_logout">登出</string>
 
+    <string name="settings_legacy_renderer_enable">改用舊式渲染器</string>
+    <string name="settings_legacy_renderer_summary">強制PixiJS引擎使用Canvas渲染器而非WebGL渲染器。可解決大部份圖形奇怪錯誤但會降低效能。</string>
+
     <string name="settings_mod_label">第三方MOD（風險自負）</string>
     <string name="settings_mod_kantai3d_enable">[Beta] Kantai3D v2.0</string>
     <string name="settings_mod_kantai3d_summary">為部份秘書艦添加仿立體的視覺效果及胸部物理。作者：@laplamgor</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -76,6 +76,9 @@
     <string name="menu_tooltip_cc">Subtitle</string>
     <string name="menu_tooltip_logout">Logout</string>
 
+    <string name="settings_legacy_renderer_enable">Use Legacy Renderer</string>
+    <string name="settings_legacy_renderer_summary">Force PixiJS game engine to use Canvas renderer instead of WebGL renderer. It may solve most display glitches but reduce performance.</string>
+
     <string name="settings_mod_label">Third Party Mods (use at your own risk)</string>
     <string name="settings_mod_kantai3d_enable">[Beta] Kantai3D v2.0</string>
     <string name="settings_mod_kantai3d_summary">Add 3D-like visual effects and jiggle physics to some of your secretaries. Author: @laplamgor</string>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -37,6 +37,12 @@
             app:key="pref_use_extcache"
             app:title="@string/settings_use_external_dir" />
 
+        <SwitchPreferenceCompat
+            app:iconSpaceReserved="false"
+            app:key="pref_legacy_renderer"
+            app:title="@string/settings_legacy_renderer_enable"
+            app:summary="@string/settings_legacy_renderer_summary"/>
+
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
Setting the user agent to change PIXI renderer type

It is the easiest way to improve compatibility,
without extra patching to the game client or PixiJS library

### Principle:
First of all, there are difference between 
A) Enable HW acceleration vs. Disable HW acceleration
B) Canvas renderer vs. WebGL renderer 

In modern chromium/webview implementation, disabling HW acceleration does not necessarily fully disable WebGL functionality.
WebView will still use software/CPU to achieve partial WebGL compatibility.
In this case, the game does not run. So, disabling HW acceleration in App-level is pointless

In order to support old devices that don't run OpenGL, PixiJS provides an option to use HTML5 Canvas renderer instead of WebGL renderer.
WebView actually has some GPU HW acceleration on Canvas applications but this PixiJS Canvas renderer is much more consistency across different HW.

Kancolle can run on Canvas renderer. Indeed, Kancolle game client has a hardcoded logic for iOS devices
if user agent is iOS device, KC will set **forceCanvas:true** when init the PIXI Application

---
Added an option in setting:
![image](https://user-images.githubusercontent.com/11514317/144075960-6a2a900e-cd5e-4692-a04f-9f0f0f42f7ff.png)

when enabled, an iOS user agent will be used in webview
`Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Mobile/15E148 Safari/604.1`

p.s. Kantai3D is forced to be disabled when using Canvas renderer because it requires WebGL


---

tested by someone who has encountered visual glitches before:
![image](https://user-images.githubusercontent.com/11514317/144077448-560fe987-5311-42e8-9deb-77a84c076c59.png)

![image](https://user-images.githubusercontent.com/11514317/144077088-f00dcae5-8c86-4f54-b1f7-0bc6aa5256f5.png)
