### PR TITLE
update SDK to API 31 and support smooth PIP animations

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.google.gms.google-services'
 apply plugin: 'com.google.firebase.crashlytics'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     defaultConfig {
         applicationId "com.antest1.gotobrowser"
         minSdkVersion 19

--- a/app/src/main/java/com/antest1/gotobrowser/Activity/BrowserActivity.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Activity/BrowserActivity.java
@@ -20,6 +20,7 @@ import android.util.Log;
 import android.util.Rational;
 import android.view.GestureDetector;
 import android.view.MotionEvent;
+import android.view.ScaleGestureDetector;
 import android.view.Surface;
 import android.view.View;
 import android.view.ViewGroup;
@@ -37,6 +38,7 @@ import androidx.core.content.ContextCompat;
 import androidx.core.view.GravityCompat;
 
 import com.antest1.gotobrowser.Browser.BrowserGestureListener;
+import com.antest1.gotobrowser.Browser.BrowserScaleGestureListener;
 import com.antest1.gotobrowser.Browser.CustomDrawerLayout;
 import com.antest1.gotobrowser.Browser.WebViewL;
 import com.antest1.gotobrowser.Browser.WebViewManager;
@@ -81,7 +83,6 @@ public class BrowserActivity extends AppCompatActivity {
     private WebViewL mContentView;
     private ProgressDialog downloadDialog;
     private ScreenshotNotification screenshotNotification;
-    GestureDetector mDetector;
     private final K3dPatcher k3dPatcher = new K3dPatcher();
     private final FpsPatcher fpsPatcher = new FpsPatcher();
 
@@ -239,6 +240,7 @@ public class BrowserActivity extends AppCompatActivity {
         }
 
         setupSmoothPipAnimation();
+        setScaleGestureDetector(mContentView);
     }
 
     private void setupSmoothPipAnimation(){
@@ -544,6 +546,12 @@ public class BrowserActivity extends AppCompatActivity {
         }
     }
 
+    private void onUserPinchIn(View v) {
+        // User pinch in to enter pip mode
+        // Same logic as UserLeaveHint (e.g. pressing home button)
+        onUserLeaveHint();
+    }
+
     @SuppressLint("ClickableViewAccessibility")
     private void setCaptureButton() {
         kcCameraButton.setVisibility(isCaptureMode ? View.VISIBLE : View.GONE);
@@ -732,6 +740,15 @@ public class BrowserActivity extends AppCompatActivity {
         view.setOnTouchListener((v, event) -> {
             mDetector.onTouchEvent(event);
             return event.getAction() != MotionEvent.ACTION_UP;
+        });
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    private void setScaleGestureDetector(View view) {
+        ScaleGestureDetector mDetector = new ScaleGestureDetector(this, new BrowserScaleGestureListener(this, this::onUserPinchIn));
+        view.setOnTouchListener((v, event) -> {
+            mDetector.onTouchEvent(event);
+            return true;
         });
     }
 }

--- a/app/src/main/java/com/antest1/gotobrowser/Activity/BrowserActivity.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Activity/BrowserActivity.java
@@ -237,6 +237,33 @@ public class BrowserActivity extends AppCompatActivity {
                 KcUtils.showToast(getApplicationContext(), "WebView not installed");
             }
         }
+
+        setupSmoothPipAnimation();
+    }
+
+    private void setupSmoothPipAnimation(){
+        // For Android 12+, PIP behaviour is changed
+        // PIP params need to be set before calling onUserLeaveHint
+        // In order to support smoother animation
+        // Listener is called right after the user exits PiP but before animating.
+        boolean pipEnabled = sharedPref.getBoolean(PREF_PIP_MODE, false);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && supportsPiPMode() && pipEnabled) {
+            mContentView.addOnLayoutChangeListener((v, left, top, right, bottom,
+                                                    oldLeft, oldTop, oldRight, oldBottom) -> {
+                if (left != oldLeft || right != oldRight || top != oldTop
+                        || bottom != oldBottom) {
+                    final Rect sourceRectHint = new Rect();
+                    mContentView.getGlobalVisibleRect(sourceRectHint);
+                    setPictureInPictureParams(
+                            new PictureInPictureParams.Builder()
+                                    .setSeamlessResizeEnabled(false)
+                                    .setSourceRectHint(sourceRectHint)
+                                    .setAutoEnterEnabled(true)
+                                    .setAspectRatio(new Rational(1200, 720))
+                                    .build());
+                }
+            });
+        }
     }
 
     @Override
@@ -689,7 +716,7 @@ public class BrowserActivity extends AppCompatActivity {
         }
     }
 
-    public boolean supportsPiPMode () {
+    private boolean supportsPiPMode() {
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.O;
     }
 

--- a/app/src/main/java/com/antest1/gotobrowser/Browser/BrowserScaleGestureListener.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Browser/BrowserScaleGestureListener.java
@@ -1,0 +1,28 @@
+package com.antest1.gotobrowser.Browser;
+
+import android.view.ScaleGestureDetector;
+import android.view.View;
+
+import com.antest1.gotobrowser.Activity.BrowserActivity;
+import com.antest1.gotobrowser.R;
+
+public class BrowserScaleGestureListener extends ScaleGestureDetector.SimpleOnScaleGestureListener {
+    private final View browserPanel;
+
+    public BrowserScaleGestureListener(BrowserActivity activity, View.OnClickListener onClickListener) {
+        this.onClickListener = onClickListener;
+        browserPanel = activity.findViewById(R.id.browser_panel);
+    }
+
+    View.OnClickListener onClickListener;
+
+    @Override
+    public boolean onScale(ScaleGestureDetector detector) {
+        if (detector.getScaleFactor() < 0.5) {
+            // Zoom In
+            onClickListener.onClick(browserPanel);
+            return true;
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
- Improve the "enter PIP mode" animation when using "swap up to home" gesture in Android 12+
- Add another method to enter enter PIP mode (pinch in under browser view)
  - in this way, the background will be your recent app instead of home screen

### Background:
in Android 12, PIP animation is enhanced in system level (especially when entering PIP mode using gesture navigation to swap up to home)
But it requires developer to change code to make use of the feature.

This is BEFORE code change in Android 12

https://user-images.githubusercontent.com/11514317/151845856-fb8381cf-8d08-4322-94f8-fb8b37b39bea.mp4


This is AFTER code change in Android 12

https://user-images.githubusercontent.com/11514317/151845900-9359ce11-3ed6-43d7-a91b-ff85c9bffd99.mp4

in Android 11 or earlier, no difference will be observed.



This is pinch in demo 

https://user-images.githubusercontent.com/11514317/152000404-a6e8c3ef-af20-49bb-8b2d-a47ba08cb142.mp4







reference: https://developer.android.com/about/versions/12/features#pip-improvements