### PR TITLE
Fixed long pending css

### DIFF
--- a/app/src/main/java/com/antest1/gotobrowser/Browser/ResourceProcess.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Browser/ResourceProcess.java
@@ -421,6 +421,9 @@ public class ResourceProcess {
                 return new WebResourceResponse("text/css", "utf-8", is);
             }
 
+            if (url.contains("kcscontents/css/default.css")) return getEmptyResponse();
+            if (url.contains("kcscontents/css/style.css")) return getEmptyResponse();
+
             if (url.contains("www.dmm.com.netgame.css")) {
                 byte[] byteArray = KcUtils.downloadDataFromURL(url);
                 String css = new String(byteArray, StandardCharsets.UTF_8);

--- a/app/src/main/java/com/antest1/gotobrowser/Constants.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Constants.java
@@ -118,13 +118,13 @@ public class Constants {
     public static final String SUBTITLE_PATH_FORMAT = "data/%s/quotes.json";
 
     public static final String[] REQUEST_BLOCK_RULES = {
-        "twitter.com/i/jot",
-        "dmm.com/latest/js/dmm.tracking",
-        "doubleclick.net",
-        "googletagmanager.com/",
-        "facebook.com",
-        "pics.dmm.com/",
-        "/uikit"
+            "twitter.com/i/jot",
+            "dmm.com/latest/js/dmm.tracking",
+            "doubleclick.net",
+            "googletagmanager.com/",
+            "facebook.com",
+            "pics.dmm.com/",
+            "/uikit"
     };
 
     public static final String[] KANCOLLE_SERVER_LIST = {
@@ -133,7 +133,7 @@ public class Constants {
             "125.6.184.215",
             "203.104.209.183",
             "203.104.209.150",
-            "203.104.209.150",
+            "203.104.209.134",
             "203.104.209.167",
             "203.104.209.199",
             "125.6.189.7",


### PR DESCRIPTION
### Long game startup fix
In some cases when using gadget bypass and auto layout with mobile data, default.css and style.css would remain pending and freeze the loading of the game until their loading failed, and the game finally booted up. I added an exception when auto layout is enabled where GotoBrowser will now return an empty response for these css sheets. This admittedly fixes the long loading issue some people were experiencing.

![image](https://user-images.githubusercontent.com/41118330/155012368-66a07d79-8656-4d6c-8d2d-5e9d8752590e.png)
*Before*
![image](https://user-images.githubusercontent.com/41118330/155012319-49d585c1-86e4-41e9-b78d-f94a81070386.png)
*After (notice the difference on the waterfall column)*

#### Light cleanup
Also cleaned up the Constants.java indents and fixed a mistake in the Kancolle server list (even if it isn't used currently).