### PR TITLE
Add True Critical Hits mod

### DIFF
--- a/app/src/main/java/com/antest1/gotobrowser/Activity/BrowserActivity.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Activity/BrowserActivity.java
@@ -44,6 +44,7 @@ import com.antest1.gotobrowser.Browser.WebViewL;
 import com.antest1.gotobrowser.Browser.WebViewManager;
 import com.antest1.gotobrowser.BuildConfig;
 import com.antest1.gotobrowser.Helpers.BackPressCloseHandler;
+import com.antest1.gotobrowser.Helpers.CritPatcher;
 import com.antest1.gotobrowser.Helpers.FpsPatcher;
 import com.antest1.gotobrowser.Helpers.K3dPatcher;
 import com.antest1.gotobrowser.Helpers.KcUtils;
@@ -84,6 +85,7 @@ public class BrowserActivity extends AppCompatActivity {
     private ProgressDialog downloadDialog;
     private ScreenshotNotification screenshotNotification;
     private final K3dPatcher k3dPatcher = new K3dPatcher();
+    private final CritPatcher critPatcher = new CritPatcher();
     private final FpsPatcher fpsPatcher = new FpsPatcher();
 
     private boolean isKcBrowserMode = false;
@@ -108,6 +110,7 @@ public class BrowserActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         k3dPatcher.prepare(this);
         fpsPatcher.prepare(this);
+        critPatcher.prepare(this);
 
         Log.e("GOTO", "enter");
         super.onCreate(savedInstanceState);

--- a/app/src/main/java/com/antest1/gotobrowser/Activity/SettingsActivity.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Activity/SettingsActivity.java
@@ -25,8 +25,6 @@ import com.antest1.gotobrowser.R;
 import com.antest1.gotobrowser.Subtitle.SubtitleProviderUtils;
 import com.google.android.material.snackbar.Snackbar;
 
-import java.util.Map;
-
 import static com.antest1.gotobrowser.Constants.DEFAULT_ALTER_GADGET_URL;
 import static com.antest1.gotobrowser.Constants.GITHUBAPI_ROOT;
 import static com.antest1.gotobrowser.Constants.PREF_ALTER_ENDPOINT;
@@ -36,14 +34,15 @@ import static com.antest1.gotobrowser.Constants.PREF_ALTER_METHOD_PROXY;
 import static com.antest1.gotobrowser.Constants.PREF_APP_VERSION;
 import static com.antest1.gotobrowser.Constants.PREF_CHECK_UPDATE;
 import static com.antest1.gotobrowser.Constants.PREF_DEVTOOLS_DEBUG;
+import static com.antest1.gotobrowser.Constants.PREF_DOWNLOAD_RETRY;
 import static com.antest1.gotobrowser.Constants.PREF_FONT_PREFETCH;
 import static com.antest1.gotobrowser.Constants.PREF_LEGACY_RENDERER;
 import static com.antest1.gotobrowser.Constants.PREF_MOD_FPS;
+import static com.antest1.gotobrowser.Constants.PREF_MOD_CRIT;
 import static com.antest1.gotobrowser.Constants.PREF_MOD_KANTAI3D;
 import static com.antest1.gotobrowser.Constants.PREF_MULTIWIN_MARGIN;
 import static com.antest1.gotobrowser.Constants.PREF_PANEL_METHOD;
 import static com.antest1.gotobrowser.Constants.PREF_PIP_MODE;
-import static com.antest1.gotobrowser.Constants.PREF_DOWNLOAD_RETRY;
 import static com.antest1.gotobrowser.Constants.PREF_SETTINGS;
 import static com.antest1.gotobrowser.Constants.PREF_SUBTITLE_LOCALE;
 import static com.antest1.gotobrowser.Constants.PREF_SUBTITLE_UPDATE;
@@ -51,6 +50,8 @@ import static com.antest1.gotobrowser.Constants.PREF_TP_DISCLAIMED;
 import static com.antest1.gotobrowser.Constants.PREF_USE_EXTCACHE;
 import static com.antest1.gotobrowser.Constants.VERSION_TABLE_VERSION;
 import static com.antest1.gotobrowser.Helpers.KcUtils.getRetrofitAdapter;
+
+import java.util.Map;
 
 public class SettingsActivity extends AppCompatActivity {
     @Override
@@ -82,6 +83,7 @@ public class SettingsActivity extends AppCompatActivity {
                 case PREF_TP_DISCLAIMED:
                 case PREF_MOD_KANTAI3D:
                 case PREF_MOD_FPS:
+                case PREF_MOD_CRIT:
                 case PREF_USE_EXTCACHE:
                 case PREF_LEGACY_RENDERER:
                     editor.putBoolean(key, false);

--- a/app/src/main/java/com/antest1/gotobrowser/Browser/ResourceProcess.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Browser/ResourceProcess.java
@@ -13,6 +13,7 @@ import android.webkit.WebResourceResponse;
 import android.widget.TextView;
 
 import com.antest1.gotobrowser.Activity.BrowserActivity;
+import com.antest1.gotobrowser.Helpers.CritPatcher;
 import com.antest1.gotobrowser.Helpers.FpsPatcher;
 import com.antest1.gotobrowser.Helpers.K3dPatcher;
 import com.antest1.gotobrowser.Helpers.KcUtils;
@@ -49,8 +50,8 @@ import static com.antest1.gotobrowser.Constants.PREF_ALTER_GADGET;
 import static com.antest1.gotobrowser.Constants.PREF_ALTER_METHOD;
 import static com.antest1.gotobrowser.Constants.PREF_ALTER_METHOD_URL;
 import static com.antest1.gotobrowser.Constants.PREF_BROADCAST;
-import static com.antest1.gotobrowser.Constants.PREF_FONT_PREFETCH;
 import static com.antest1.gotobrowser.Constants.PREF_DOWNLOAD_RETRY;
+import static com.antest1.gotobrowser.Constants.PREF_FONT_PREFETCH;
 import static com.antest1.gotobrowser.Constants.PREF_SUBTITLE_LOCALE;
 import static com.antest1.gotobrowser.Constants.REQUEST_BLOCK_RULES;
 import static com.antest1.gotobrowser.Constants.VERSION_TABLE_VERSION;
@@ -637,6 +638,7 @@ public class ResourceProcess {
 
         main_js = K3dPatcher.patchKantai3d(main_js);
         main_js = FpsPatcher.patchFps(main_js);
+        main_js = CritPatcher.patchCrit(main_js);
 
         // manage bgm loading strategy with global mute variable for audio focus issue
         if (activity.isMuteMode()) {

--- a/app/src/main/java/com/antest1/gotobrowser/Constants.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Constants.java
@@ -38,6 +38,7 @@ public class Constants {
     public static final String PREF_LEGACY_RENDERER = "pref_legacy_renderer";
     public static final String PREF_MOD_KANTAI3D = "pref_mod_kantai3d";
     public static final String PREF_MOD_FPS = "pref_mod_fps";
+    public static final String PREF_MOD_CRIT = "pref_mod_crit";
     public static final String PREF_USE_EXTCACHE = "pref_use_extcache";
     public static final String PREF_UI_HELP_CHECKED = "pref_ui_help_checked";
     public static final String PREF_DOWNLOAD_RETRY = "pref_retry";
@@ -57,6 +58,7 @@ public class Constants {
             PREF_LEGACY_RENDERER,
             PREF_MOD_KANTAI3D,
             PREF_MOD_FPS,
+            PREF_MOD_CRIT,
             PREF_USE_EXTCACHE
     };
 

--- a/app/src/main/java/com/antest1/gotobrowser/Helpers/CritPatcher.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Helpers/CritPatcher.java
@@ -1,0 +1,56 @@
+package com.antest1.gotobrowser.Helpers;
+
+import static com.antest1.gotobrowser.Constants.PREF_MOD_CRIT;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import com.antest1.gotobrowser.R;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class CritPatcher {
+    private static boolean isPatcherEnabled = false;
+
+    public void prepare(Activity activity) {
+        // Only update the enable status when opening the browser view
+        // Require reopening the browser after switching the MOD on or off
+        SharedPreferences sharedPref = activity.getSharedPreferences(
+                activity.getString(R.string.preference_key), Context.MODE_PRIVATE);
+        isPatcherEnabled = sharedPref.getBoolean(PREF_MOD_CRIT, false);
+    }
+
+
+    public static String patchCrit(String main_js){
+        if (!isPatcherEnabled) {
+            return main_js;
+        }
+
+        Map<String, String> stringsToReplace = new LinkedHashMap<>();
+
+        // Deletes the line responsible for damage nature obfuscation
+        stringsToReplace.put(
+                "null\\),.{0,99}<\\=0x0\\?.{0,99}\\=0x0\\:.{0,99}<\\=.{0,99}\\?.{0,99}\\=0x2\\:.{0,99}<0xf&&0x2\\=\\=.{0,99}&&\\(_0x.{0,99}\\=0x1\\)",
+                "null)");
+
+        String replaced = main_js;
+        for (Map.Entry<String, String> stringToReplace : stringsToReplace.entrySet()) {
+            Pattern pattern = Pattern.compile(stringToReplace.getKey());
+            Matcher matcher = pattern.matcher(replaced);
+            if (matcher.find() && !matcher.find()) {
+                // Find one and only one match
+                matcher.reset();
+                replaced = matcher.replaceFirst(stringToReplace.getValue());
+            } else {
+                // The main.js is probably updated and no longer supports the crit patch currently
+                // Immediately return the unpatched main.js
+                return main_js;
+            }
+        }
+        return replaced;
+    }
+}

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -75,6 +75,8 @@
     <string name="settings_mod_kantai3d_about">About Kantai3D</string>
     <string name="settings_mod_fps_enable">60FPS制限を削除します</string>
     <string name="settings_mod_fps_summary">高リフレッシュ・レート対応。ゲームの速度は影響を受けません。</string>
+    <string name="settings_mod_crit_enable">真のクリティカルヒット</string>
+    <string name="settings_mod_crit_summary">ハードコードされたヒットの難読化を削除します。 クリティカルヒットのみがそのように表示されます。 作者：@Oradimi</string>
     <string name="settings_use_external_dir">キャッシングに外部ストレージを使用</string>
     <string name="menu_tooltip_kantai3d">3D効果</string>
     <string name="msg_kantai3d_init">秘書艦が検出されません</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -76,6 +76,8 @@
     <string name="settings_mod_kantai3d_about">About Kantai3D</string>
     <string name="settings_mod_fps_enable">60FPS 제한 제거</string>
     <string name="settings_mod_fps_summary">더 높은 화면 재생 빈도 장치를 지원합니다. 애니메이션 속도는 영향을 받지 않습니다.</string>
+    <string name="settings_mod_crit_enable">진정한 크리티컬 히트</string>
+    <string name="settings_mod_crit_summary">하드 코딩된 히트의 난독화를 제거합니다. 크리티컬 히트만 크리티컬 히트로 표시됩니다. 저자: @Oradimi</string>
     <string name="settings_use_external_dir">리소스 캐싱 시 외부 저장소 사용</string>
     <string name="menu_tooltip_kantai3d">3D 적용</string>
     <string name="msg_kantai3d_init">비서함 감지 안됨</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -74,6 +74,8 @@
     <string name="settings_mod_kantai3d_about">About Kantai3D</string>
     <string name="settings_mod_fps_enable">移除60帧限制</string>
     <string name="settings_mod_fps_summary">支持高刷新率手机。游戏速度不会受影响。</string>
+    <string name="settings_mod_crit_enable">真正的致命一击</string>
+    <string name="settings_mod_crit_summary">删除命中的一些硬编码混淆。 只有重击才会这样显示，等等。作者：@Oradimi</string>
     <string name="settings_use_external_dir">使用外部存储进行缓存</string>
     <string name="menu_tooltip_kantai3d">开关立体效果</string>
     <string name="msg_kantai3d_init">未检测到秘书舰</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -74,6 +74,8 @@
     <string name="settings_mod_kantai3d_about">About Kantai3D</string>
     <string name="settings_mod_fps_enable">移除60幀限制</string>
     <string name="settings_mod_fps_summary">支持高刷新率手機。遊戲速度不會受影響。</string>
+    <string name="settings_mod_crit_enable">真正的致命一擊</string>
+    <string name="settings_mod_crit_summary">刪除命中的一些硬編碼混淆。 只有重擊才會這樣顯示，等等。作者：@Oradimi</string>
     <string name="settings_use_external_dir">使用外部存儲存放快取</string>
     <string name="menu_tooltip_kantai3d">開關立體效果</string>
     <string name="msg_kantai3d_init">未偵察到秘書艦</string>

--- a/app/src/main/res/values-zh-rMO/strings.xml
+++ b/app/src/main/res/values-zh-rMO/strings.xml
@@ -74,6 +74,8 @@
     <string name="settings_mod_kantai3d_about">About Kantai3D</string>
     <string name="settings_mod_fps_enable">移除60幀限制</string>
     <string name="settings_mod_fps_summary">支持高刷新率手機。遊戲速度不會受影響。</string>
+    <string name="settings_mod_crit_enable">真正的致命一擊</string>
+    <string name="settings_mod_crit_summary">刪除命中的一些硬編碼混淆。 只有重擊才會這樣顯示，等等。作者：@Oradimi</string>
     <string name="settings_use_external_dir">使用外部存儲存放快取</string>
     <string name="menu_tooltip_kantai3d">開關立體效果</string>
     <string name="msg_kantai3d_init">未偵察到秘書艦</string>

--- a/app/src/main/res/values-zh-rSG/strings.xml
+++ b/app/src/main/res/values-zh-rSG/strings.xml
@@ -74,6 +74,8 @@
     <string name="settings_mod_kantai3d_about">About Kantai3D</string>
     <string name="settings_mod_fps_enable">移除60帧限制</string>
     <string name="settings_mod_fps_summary">支持高刷新率手机。游戏速度不会受影响。</string>
+    <string name="settings_mod_crit_enable">真正的致命一击</string>
+    <string name="settings_mod_crit_summary">删除命中的一些硬编码混淆。 只有重击才会这样显示，等等。作者：@Oradimi</string>
     <string name="settings_use_external_dir">使用外部存储进行缓存</string>
     <string name="menu_tooltip_kantai3d">开关立体效果</string>
     <string name="msg_kantai3d_init">未检测到秘书舰</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -74,6 +74,8 @@
     <string name="settings_mod_kantai3d_about">About Kantai3D</string>
     <string name="settings_mod_fps_enable">移除60幀限制</string>
     <string name="settings_mod_fps_summary">支持高刷新率手機。遊戲速度不會受影響。</string>
+    <string name="settings_mod_crit_enable">真正的致命一擊</string>
+    <string name="settings_mod_crit_summary">刪除命中的一些硬編碼混淆。 只有重擊才會這樣顯示，等等。作者：@Oradimi</string>
     <string name="settings_use_external_dir">使用外部存儲存放緩存</string>
     <string name="menu_tooltip_kantai3d">開關立體效果</string>
     <string name="msg_kantai3d_init">未偵察到秘書艦</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,6 +85,8 @@
     <string name="settings_mod_kantai3d_about">About Kantai3D</string>
     <string name="settings_mod_fps_enable">Remove 60 FPS limit</string>
     <string name="settings_mod_fps_summary">Support higher refresh rate devices. Animation speed is not affected.</string>
+    <string name="settings_mod_crit_enable">True Critical Hits</string>
+    <string name="settings_mod_crit_summary">Removes some hard-coded obfuscation for hits. Only a critical hit will be displayed as such, etc. Author: @Oradimi</string>
     <string name="settings_use_external_dir">Use External Storage for Resource Caching</string>
     <string name="menu_tooltip_kantai3d">Toggle 3D effects</string>
     <string name="msg_kantai3d_init">No secretary detected</string>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -121,6 +121,12 @@
                 android:action="android.intent.action.VIEW"
                 android:data="https://github.com/laplamgor/kantai3d"/>
         </Preference>
+
+        <SwitchPreferenceCompat
+            android:summary="@string/settings_mod_crit_summary"
+            app:iconSpaceReserved="false"
+            app:key="pref_mod_crit"
+            app:title="@string/settings_mod_crit_enable" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
This mod deletes the line of the game's client responsible for displaying every damage above 39 as critical hits, every damage below 15 as not critical hits, and 0 damage hits as misses. It makes it possible to see the real nature of your ships' hits directly within the game.

There is currently a crash issue, where these lines in Settings Activity are causing a crash when opening the settings. Investigation needed. But commenting them out works, and the mod is functional.

![image](https://cdn.discordapp.com/attachments/692787156053131326/945471932336312421/unknown.png)