### PR TITLE
Fix crashes

### DIFF
--- a/app/src/main/java/com/antest1/gotobrowser/Activity/EntranceActivity.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Activity/EntranceActivity.java
@@ -288,9 +288,12 @@ public class EntranceActivity extends AppCompatActivity {
 
             if (prefAlterGadget && isProxyMethod && pref_connector.equals(CONN_DMM)) {
                 WebViewManager.setKcCacheProxy(alterEndpoint, () -> {
-                    startActivity(intent);
-                    finish();
-                });
+                            startActivity(intent);
+                            finish();
+                        },
+                        () -> {
+                            KcUtils.showToast(getApplicationContext(), R.string.setting_alter_method_proxy_error_toast);
+                        });
             } else {
                 startActivity(intent);
                 finish();

--- a/app/src/main/java/com/antest1/gotobrowser/Browser/WebViewManager.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Browser/WebViewManager.java
@@ -416,7 +416,7 @@ public class WebViewManager {
         return url.replace(GADGET_URL, endpoint);
     }
 
-    public static void setKcCacheProxy(String endpoint, Runnable listener) {
+    public static void setKcCacheProxy(String endpoint, Runnable onSuccessListener, Runnable onFailureListener) {
         if (WebViewFeature.isFeatureSupported(WebViewFeature.PROXY_OVERRIDE)) {
             ProxyConfig proxyConfig = new ProxyConfig.Builder()
                     .addProxyRule(endpoint)
@@ -425,7 +425,11 @@ public class WebViewManager {
             Executor executor = command -> {
                 command.run();
             };
-            ProxyController.getInstance().setProxyOverride(proxyConfig, executor, listener);
+            try {
+                ProxyController.getInstance().setProxyOverride(proxyConfig, executor, onSuccessListener);
+            } catch (IllegalArgumentException exception) {
+                onFailureListener.run();
+            }
         }
     }
 

--- a/app/src/main/java/com/antest1/gotobrowser/Subtitle/Kc3SubtitleProvider.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Subtitle/Kc3SubtitleProvider.java
@@ -180,7 +180,7 @@ public class Kc3SubtitleProvider implements SubtitleProvider {
     }
 
     public boolean loadQuoteData(Context context, String localeCode) {
-        // For KC3 Kai data format, need to load the quite size meta first
+        // For KC3 Kai data format, need to load the quote size meta first
         loadQuoteAnnotation(context);
 
         String filename = String.format(Locale.US, "quotes_%s.json", localeCode);
@@ -232,7 +232,7 @@ public class Kc3SubtitleProvider implements SubtitleProvider {
                     String commit = commit_log.get(0).getAsJsonObject().get("sha").getAsString();
                     downloadQuoteSizeData(versionTable, context, commit, submeta_file);
                     loadQuoteSizeData(submeta_path);
-                    Log.e("GOTO", "quote_size: " + quoteSizeData.size());
+                    Log.e("GOTO", "quote_size: " + (quoteSizeData == null ? -1 : quoteSizeData.size()));
                 }
             }
             @Override
@@ -243,7 +243,7 @@ public class Kc3SubtitleProvider implements SubtitleProvider {
         });
 
 
-        Log.e("GOTO", "quote_meta: " + quoteLabel.size());
+        Log.e("GOTO", "quote_meta: " + (quoteLabel == null ? -1 : quoteLabel.size()));
     }
 
     private static void downloadQuoteSizeData(VersionDatabase table, Context context, String commit, File file) {

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -55,6 +55,7 @@
     <string name="setting_connection">接続設定</string>
     <string name="setting_alter_method_url">URL置換</string>
     <string name="setting_alter_method_proxy">KCCacheProxy（リモート）</string>
+    <string name="setting_alter_method_proxy_error_toast">KCCacheProxyエンドポイントサーバーが無効です。バイパス方式設定を変更してください。</string>
     <string name="setting_alter_method">バイパス方式</string>
     <string name="setting_alter_endpoint">エンドポイントサーバー</string>
 

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -56,6 +56,7 @@
     <string name="setting_connection">접속 설정</string>
     <string name="setting_alter_method_url">URL 교체</string>
     <string name="setting_alter_method_proxy">KCCacheProxy (remote)</string>
+    <string name="setting_alter_method_proxy_error_toast">KCCacheProxy Endpoint Server is invalid. Please update your Bypass Method setting.</string>
     <string name="setting_alter_method">우회 방식</string>
     <string name="setting_alter_endpoint">Endpoint 서버</string>
 

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -54,6 +54,7 @@
     <string name="setting_connection">连接设置</string>
     <string name="setting_alter_method_url">URL替换</string>
     <string name="setting_alter_method_proxy">KCCacheProxy（远程服务器）</string>
+    <string name="setting_alter_method_proxy_error_toast">KCCacheProxy端点服务器无效。请更改绕行方式设定。</string>
     <string name="setting_alter_method">绕行方式</string>
     <string name="setting_alter_endpoint">端点服务器</string>
 

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -54,6 +54,7 @@
     <string name="setting_connection">連接設定</string>
     <string name="setting_alter_method_url">URL替換</string>
     <string name="setting_alter_method_proxy">KCCacheProxy（遠端伺服器）</string>
+    <string name="setting_alter_method_proxy_error_toast">KCCacheProxy端點伺服器無效。請更改繞行方式設定。</string>
     <string name="setting_alter_method">繞行方式</string>
     <string name="setting_alter_endpoint">端點伺服器</string>
 

--- a/app/src/main/res/values-zh-rMO/strings.xml
+++ b/app/src/main/res/values-zh-rMO/strings.xml
@@ -54,6 +54,7 @@
     <string name="setting_connection">連接設定</string>
     <string name="setting_alter_method_url">URL替換</string>
     <string name="setting_alter_method_proxy">KCCacheProxy（遠端伺服器）</string>
+    <string name="setting_alter_method_proxy_error_toast">KCCacheProxy端點伺服器無效。請更改繞行方式設定。</string>
     <string name="setting_alter_method">繞行方式</string>
     <string name="setting_alter_endpoint">端點伺服器</string>
 

--- a/app/src/main/res/values-zh-rSG/strings.xml
+++ b/app/src/main/res/values-zh-rSG/strings.xml
@@ -55,6 +55,7 @@
     <string name="setting_alter_method_url">URL替换</string>
     <string name="setting_alter_method_proxy">KCCacheProxy（远程服务器）</string>
     <string name="setting_alter_method">绕行方式</string>
+    <string name="setting_alter_method_proxy_error_toast">KCCacheProxy端点服务器无效。请更改绕行方式设定。</string>
     <string name="setting_alter_endpoint">端点服务器</string>
 
     <string name="menu_tooltip_refresh">刷新页面</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -54,6 +54,7 @@
     <string name="setting_connection">連接設定</string>
     <string name="setting_alter_method_url">URL替換</string>
     <string name="setting_alter_method_proxy">KCCacheProxy（遠端伺服器）</string>
+    <string name="setting_alter_method_proxy_error_toast">KCCacheProxy端點伺服器無效。請更改繞行方式設定。</string>
     <string name="setting_alter_method">繞行方式</string>
     <string name="setting_alter_endpoint">端點伺服器</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,6 +66,7 @@
     <string name="setting_alter_method">Bypass Method</string>
     <string name="setting_alter_method_url">URL Replacement</string>
     <string name="setting_alter_method_proxy">KCCacheProxy (remote)</string>
+    <string name="setting_alter_method_proxy_error_toast">KCCacheProxy Endpoint Server is invalid. Please update your Bypass Method setting.</string>
     <string name="setting_alter_endpoint">Endpoint Server</string>
 
     <string name="menu_tooltip_refresh">Refresh</string>


### PR DESCRIPTION
1. For some reason KC3 subtitle data is corrupted and a logger caused a null pointer exception crash.
2. Corrupted data is most likely caused by a new user not yet selecting any subtitle language (but Goto trying to run the English (KC3) subtitle logic, especially if the user doesn't have good network connection to Github website
   - a DummySubtitleProvider is now introduced for default logic
4. Some users don't understand what KCCP is but choose it as the bypass method, caused an immediate crash at game start.
   - a toast message will warn the user now. (Korea translation missing)