### PR TITLE
Fix True Critical Hit mod

### DIFF
--- a/app/src/main/java/com/antest1/gotobrowser/Helpers/CritPatcher.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Helpers/CritPatcher.java
@@ -34,7 +34,7 @@ public class CritPatcher {
 
         // Deletes the line responsible for damage nature obfuscation
         stringsToReplace.put(
-                "null\\),.{0,99}<\\=0x0\\?.{0,99}\\=0x0\\:.{0,99}<\\=.{0,99}\\?.{0,99}\\=0x2\\:.{0,99}<0xf&&0x2\\=\\=.{0,99}&&\\(_0x.{0,99}\\=0x1\\)",
+                "null\\),.{0,99}<\\=(0x)?0\\?.{0,99}\\=(0x)?0\\:.{0,99}<\\=.{0,99}\\?.{0,99}\\=(0x)?2\\:.{0,99}<(0xf|15)&&(0x)?2\\=\\=.{0,99}&&\\(.{0,99}\\=(0x)?1\\)",
                 "null)");
 
         String replaced = main_js;


### PR DESCRIPTION
Mod got broken from devs uploading an unobfuscated main.js. The mod will now work for both obfuscated and unobfuscated main.js.