### PR TITLE
fix kccp language patch settings

### DIFF
--- a/app/src/main/java/com/antest1/gotobrowser/Activity/EntranceActivity.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Activity/EntranceActivity.java
@@ -8,7 +8,6 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.view.View;
 import android.webkit.WebView;
-import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.TextView;
 
@@ -53,7 +52,7 @@ import static com.antest1.gotobrowser.Constants.PREF_DMM_PASS;
 import static com.antest1.gotobrowser.Constants.PREF_KEYBOARD;
 import static com.antest1.gotobrowser.Constants.PREF_LATEST_URL;
 import static com.antest1.gotobrowser.Constants.PREF_BROADCAST;
-import static com.antest1.gotobrowser.Constants.PREF_MOD_KANTAIEN;
+import static com.antest1.gotobrowser.Constants.PREF_MOD_KCCP_LANG_PATCH;
 import static com.antest1.gotobrowser.Constants.PREF_PANELSTART;
 import static com.antest1.gotobrowser.Constants.PREF_SILENT;
 import static com.antest1.gotobrowser.Constants.PREF_TP_DISCLAIMED;
@@ -155,7 +154,7 @@ public class EntranceActivity extends AppCompatActivity {
         }
 
         KcEnUtils enUtils = new KcEnUtils();
-        if (sharedPref.getBoolean(PREF_MOD_KANTAIEN, false)) {
+        if (sharedPref.getBoolean(PREF_MOD_KCCP_LANG_PATCH, false)) {
             String availableVersion = enUtils.checkKantaiEnUpdateEntrance(this);
             if (availableVersion != null) {
                 MaterialAlertDialogBuilder alertDialogBuilder = new MaterialAlertDialogBuilder(this);

--- a/app/src/main/java/com/antest1/gotobrowser/Activity/SettingsActivity.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Activity/SettingsActivity.java
@@ -29,7 +29,6 @@ import com.antest1.gotobrowser.BuildConfig;
 import com.antest1.gotobrowser.Helpers.GotoVersionCheck;
 import com.antest1.gotobrowser.Helpers.KcEnUtils;
 import com.antest1.gotobrowser.Helpers.KcUtils;
-import com.antest1.gotobrowser.Helpers.KenPatcher;
 import com.antest1.gotobrowser.Helpers.VersionDatabase;
 import com.antest1.gotobrowser.Preference.MaterialListPreference;
 import com.antest1.gotobrowser.R;
@@ -69,7 +68,6 @@ import static com.antest1.gotobrowser.Constants.PREF_MOD_KANTAIEN_DELETE;
 import static com.antest1.gotobrowser.Constants.PREF_MOD_KANTAIEN_UPDATE;
 import static com.antest1.gotobrowser.Constants.PREF_MOD_CRIT;
 import static com.antest1.gotobrowser.Constants.PREF_MOD_KANTAI3D;
-import static com.antest1.gotobrowser.Constants.PREF_MOD_KANTAIID;
 import static com.antest1.gotobrowser.Constants.PREF_MOD_KCCP_LANG_PATCH_EN;
 import static com.antest1.gotobrowser.Constants.PREF_MOD_KCCP_LANG_PATCH_GITHUB;
 import static com.antest1.gotobrowser.Constants.PREF_MOD_KCCP_LANG_PATCH_ID;
@@ -122,7 +120,6 @@ public class SettingsActivity extends AppCompatActivity {
                 case PREF_DEVTOOLS_DEBUG:
                 case PREF_TP_DISCLAIMED:
                 case PREF_MOD_KANTAI3D:
-                case PREF_MOD_KANTAIID:
                 case PREF_MOD_FPS:
                 case PREF_MOD_CRIT:
                 case PREF_LEGACY_RENDERER:
@@ -223,7 +220,7 @@ public class SettingsActivity extends AppCompatActivity {
                 version_pref.setSummary(BuildConfig.VERSION_NAME);
             }
             updateSubtitleDescriptionText();
-            updateKCCPLangPatchDescriptionText();
+            updateKCCPLangPatchDescriptionText(null);
             updateKCCPLangPatchInfo(null);
             updateKantai3dDisable();
         }
@@ -244,7 +241,7 @@ public class SettingsActivity extends AppCompatActivity {
                             enUtils.requestPatchUpdate(this);
                         }
                     } catch (IOException e) {
-                        e.printStackTrace();
+                        Log.e("GOTO", KcUtils.getStringFromException(e));
                     }
                     break;
                 case PREF_MOD_KANTAIEN_DELETE:
@@ -303,6 +300,7 @@ public class SettingsActivity extends AppCompatActivity {
 
                 if (key.equals(PREF_MOD_KCCP_LANG_PATCH_NAME)) {
                     updateKCCPLangPatchInfo(stringValue);
+                    updateKCCPLangPatchDescriptionText(stringValue);
                 }
             }
             else if (preference instanceof EditTextPreference) {
@@ -324,7 +322,7 @@ public class SettingsActivity extends AppCompatActivity {
                 }
 
                 if (key.equals(PREF_MOD_KCCP_LANG_PATCH)) {
-                    updateKCCPLangPatchDescriptionText();
+                    updateKCCPLangPatchDescriptionText(null);
                 }
             }
             return true;
@@ -376,13 +374,14 @@ public class SettingsActivity extends AppCompatActivity {
             modKCCPLangPatchInfo.setSummary(target_url);
         }
 
-        private void updateKCCPLangPatchDescriptionText() {
+        private void updateKCCPLangPatchDescriptionText(String lang) {
             ListPreference modKCCPLangPatchName = findPreference(PREF_MOD_KCCP_LANG_PATCH_NAME);
             Preference modKCCPLangPatchUpdate = findPreference(PREF_MOD_KANTAIEN_UPDATE);
             if (modKCCPLangPatchName == null || modKCCPLangPatchUpdate == null) return;
+            if (lang == null) lang = modKCCPLangPatchName.getValue();
 
-            if (sharedPref.getBoolean(PREF_MOD_KCCP_LANG_PATCH, false) ||
-                    sharedPref.getBoolean(PREF_MOD_KANTAIID, false)) {
+            if (sharedPref.getBoolean(PREF_MOD_KCCP_LANG_PATCH, false)) {
+                enUtils.setPatchLanguage(lang);
                 enUtils.checkKantaiEnUpdate(this, modKCCPLangPatchUpdate);
             } else {
                 modKCCPLangPatchUpdate.setSummary("Mod disabled.");

--- a/app/src/main/java/com/antest1/gotobrowser/Activity/SettingsActivity.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Activity/SettingsActivity.java
@@ -3,12 +3,13 @@ package com.antest1.gotobrowser.Activity;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.content.Context;
+import android.content.Intent;
 import android.content.SharedPreferences;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
-import android.widget.SeekBar;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
@@ -62,12 +63,17 @@ import static com.antest1.gotobrowser.Constants.PREF_KEYBOARD;
 import static com.antest1.gotobrowser.Constants.PREF_LANDSCAPE;
 import static com.antest1.gotobrowser.Constants.PREF_LEGACY_RENDERER;
 import static com.antest1.gotobrowser.Constants.PREF_MOD_FPS;
-import static com.antest1.gotobrowser.Constants.PREF_MOD_KANTAIEN;
+import static com.antest1.gotobrowser.Constants.PREF_MOD_KANTAIEN_LEGACY;
+import static com.antest1.gotobrowser.Constants.PREF_MOD_KCCP_LANG_PATCH;
 import static com.antest1.gotobrowser.Constants.PREF_MOD_KANTAIEN_DELETE;
 import static com.antest1.gotobrowser.Constants.PREF_MOD_KANTAIEN_UPDATE;
 import static com.antest1.gotobrowser.Constants.PREF_MOD_CRIT;
 import static com.antest1.gotobrowser.Constants.PREF_MOD_KANTAI3D;
 import static com.antest1.gotobrowser.Constants.PREF_MOD_KANTAIID;
+import static com.antest1.gotobrowser.Constants.PREF_MOD_KCCP_LANG_PATCH_EN;
+import static com.antest1.gotobrowser.Constants.PREF_MOD_KCCP_LANG_PATCH_GITHUB;
+import static com.antest1.gotobrowser.Constants.PREF_MOD_KCCP_LANG_PATCH_ID;
+import static com.antest1.gotobrowser.Constants.PREF_MOD_KCCP_LANG_PATCH_NAME;
 import static com.antest1.gotobrowser.Constants.PREF_MULTIWIN_MARGIN;
 import static com.antest1.gotobrowser.Constants.PREF_DISABLE_REFRESH_DIALOG;
 import static com.antest1.gotobrowser.Constants.PREF_PIP_MODE;
@@ -116,7 +122,6 @@ public class SettingsActivity extends AppCompatActivity {
                 case PREF_DEVTOOLS_DEBUG:
                 case PREF_TP_DISCLAIMED:
                 case PREF_MOD_KANTAI3D:
-                case PREF_MOD_KANTAIEN:
                 case PREF_MOD_KANTAIID:
                 case PREF_MOD_FPS:
                 case PREF_MOD_CRIT:
@@ -124,6 +129,9 @@ public class SettingsActivity extends AppCompatActivity {
                 case PREF_ALTER_GADGET:
                 case PREF_DISABLE_REFRESH_DIALOG:
                     editor.putBoolean(key, false);
+                    break;
+                case PREF_MOD_KCCP_LANG_PATCH:
+                    editor.putBoolean(key, sharedPref.getBoolean(PREF_MOD_KANTAIEN_LEGACY, false));
                     break;
                 case PREF_ALTER_METHOD:
                     editor.putString(key, PREF_ALTER_METHOD_URL);
@@ -136,6 +144,9 @@ public class SettingsActivity extends AppCompatActivity {
                     break;
                 case PREF_SUBTITLE_FONTSIZE:
                     editor.putInt(key, DEFAULT_SUBTITLE_FONT_SIZE);
+                    break;
+                case PREF_MOD_KCCP_LANG_PATCH_NAME:
+                    editor.putString(key, PREF_MOD_KCCP_LANG_PATCH_EN);
                     break;
                 default:
                     editor.putString(key, "");
@@ -171,6 +182,19 @@ public class SettingsActivity extends AppCompatActivity {
                     if (preference == null) continue;
                     if (preference instanceof ListPreference) {
                         Log.e("GOTO", key + ": " + sharedPref.getString(key, ""));
+                        if (PREF_MOD_KCCP_LANG_PATCH_NAME.equals(key)) {
+                            preference.setSummaryProvider((Preference.SummaryProvider<ListPreference>) pref -> {
+                                String value = pref.getValue();
+                                Log.e("GOTO", "PREF_MOD_KCCP_LANG_PATCH_NAME: " + value);
+                                if (PREF_MOD_KCCP_LANG_PATCH_EN.equals(value)) {
+                                    return getString(R.string.settings_mod_kccp_patch_en_summary);
+                                } else if (PREF_MOD_KCCP_LANG_PATCH_ID.equals(value)) {
+                                    return getString(R.string.settings_mod_kccp_patch_id_summary);
+                                } else {
+                                    return pref.getEntry();
+                                }
+                            });
+                        }
                     } else if (preference instanceof EditTextPreference ep) {
                         Log.e("GOTO", key + ": " + sharedPref.getString(key, ""));
                         ep.setSummary(sharedPref.getString(key, ""));
@@ -188,9 +212,6 @@ public class SettingsActivity extends AppCompatActivity {
                         preference.setOnPreferenceClickListener(this);
                     }
                 }
-                updateSubtitleDescriptionText();
-                updateKantaiEnDescriptionText();
-                updateKantai3dDisable();
             }
         }
 
@@ -201,6 +222,10 @@ public class SettingsActivity extends AppCompatActivity {
             if (version_pref != null) {
                 version_pref.setSummary(BuildConfig.VERSION_NAME);
             }
+            updateSubtitleDescriptionText();
+            updateKCCPLangPatchDescriptionText();
+            updateKCCPLangPatchInfo(null);
+            updateKantai3dDisable();
         }
 
         @Override
@@ -270,9 +295,14 @@ public class SettingsActivity extends AppCompatActivity {
                         return false;
                     }
                 }
+
                 sharedPref.edit().putString(key, stringValue).apply();
                 if (key.equals(PREF_SUBTITLE_LOCALE)) {
                     setSubtitlePreference(stringValue);
+                }
+
+                if (key.equals(PREF_MOD_KCCP_LANG_PATCH_NAME)) {
+                    updateKCCPLangPatchInfo(stringValue);
                 }
             }
             else if (preference instanceof EditTextPreference) {
@@ -285,14 +315,16 @@ public class SettingsActivity extends AppCompatActivity {
                 boolean value = (boolean) newValue;
                 sharedPref.edit().putBoolean(key, value).apply();
 
-                handleMutualExclusiveMods(key, value);
-
                 if (key.equals(PREF_USE_EXTCACHE)) {
                     updateSubtitleDescriptionText();
                 }
 
                 if (key.equals(PREF_LEGACY_RENDERER)) {
                     updateKantai3dDisable();
+                }
+
+                if (key.equals(PREF_MOD_KCCP_LANG_PATCH)) {
+                    updateKCCPLangPatchDescriptionText();
                 }
             }
             return true;
@@ -324,38 +356,37 @@ public class SettingsActivity extends AppCompatActivity {
             SubtitleProviderUtils.getSubtitleProvider(subtitleLocaleCode).checkUpdateFromPreference(this, subtitleLocaleCode, subtitleUpdate, versionTable);
         }
 
-        private void updateKantaiEnDescriptionText() {
-            Preference kantaiEnUpdate = findPreference(PREF_MOD_KANTAIEN_UPDATE);
-            if (kantaiEnUpdate != null) {
-                if (sharedPref.getBoolean(PREF_MOD_KANTAIEN, false) ||
-                        sharedPref.getBoolean(PREF_MOD_KANTAIID, false)) {
-                    enUtils.checkKantaiEnUpdate(this, kantaiEnUpdate);
-                } else {
-                    kantaiEnUpdate.setEnabled(false);
-                    kantaiEnUpdate.setSummary("Mod disabled.");
-                }
+        private void updateKCCPLangPatchInfo(String lang) {
+            ListPreference modKCCPLangPatchName = findPreference(PREF_MOD_KCCP_LANG_PATCH_NAME);
+            Preference modKCCPLangPatchInfo = findPreference(PREF_MOD_KCCP_LANG_PATCH_GITHUB);
+            if (modKCCPLangPatchName == null || modKCCPLangPatchInfo == null) return;
+            if (lang == null) lang = modKCCPLangPatchName.getValue();
+
+            String target_url;
+            Intent intent = new Intent(Intent.ACTION_VIEW);
+            if (PREF_MOD_KCCP_LANG_PATCH_ID.equals(lang)) {
+                target_url = getString(R.string.settings_mod_kccp_patch_id_link);
+                modKCCPLangPatchInfo.setTitle(R.string.settings_mod_kantaiid_about);
+            } else { // use EN as default
+                target_url = getString(R.string.settings_mod_kccp_patch_en_link);
+                modKCCPLangPatchInfo.setTitle(R.string.settings_mod_kantaien_about);
             }
+            intent.setData(Uri.parse(target_url));
+            modKCCPLangPatchInfo.setIntent(intent);
+            modKCCPLangPatchInfo.setSummary(target_url);
         }
 
-        private void handleMutualExclusiveMods(String key, boolean value) {
-            if (key.equals(PREF_MOD_KANTAIEN) && value) {
-                KcEnUtils.setPatchLanguage(KenPatcher.PatchLanguage.EN);
-                toggleOff(PREF_MOD_KANTAIID);
-                updateKantaiEnDescriptionText();
-            } else if (key.equals(PREF_MOD_KANTAIID) && value) {
-                KcEnUtils.setPatchLanguage(KenPatcher.PatchLanguage.ID);
-                toggleOff(PREF_MOD_KANTAIEN);
-                updateKantaiEnDescriptionText();
+        private void updateKCCPLangPatchDescriptionText() {
+            ListPreference modKCCPLangPatchName = findPreference(PREF_MOD_KCCP_LANG_PATCH_NAME);
+            Preference modKCCPLangPatchUpdate = findPreference(PREF_MOD_KANTAIEN_UPDATE);
+            if (modKCCPLangPatchName == null || modKCCPLangPatchUpdate == null) return;
+
+            if (sharedPref.getBoolean(PREF_MOD_KCCP_LANG_PATCH, false) ||
+                    sharedPref.getBoolean(PREF_MOD_KANTAIID, false)) {
+                enUtils.checkKantaiEnUpdate(this, modKCCPLangPatchUpdate);
             } else {
-                KcEnUtils.setPatchLanguage(KenPatcher.PatchLanguage.NONE);
-                updateKantaiEnDescriptionText();
+                modKCCPLangPatchUpdate.setSummary("Mod disabled.");
             }
-        }
-
-        private void toggleOff(String key) {
-            sharedPref.edit().putBoolean(key, false).apply();
-            SwitchPreferenceCompat pref = findPreference(key);
-            if (pref != null) pref.setChecked(false);
         }
 
         private void showSubtitleFontSizeDialog(FragmentActivity activity) {

--- a/app/src/main/java/com/antest1/gotobrowser/Browser/ResourceProcess.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Browser/ResourceProcess.java
@@ -247,6 +247,7 @@ public class ResourceProcess {
             }
 
         } catch (Exception e) {
+            Log.e("GOTO", KcUtils.getStringFromException(e));
             KcUtils.reportException(e);
         }
         return null;
@@ -381,7 +382,7 @@ public class ResourceProcess {
         String log_path = out_file_path;
         File file = getImageFile(out_file_path);
 
-        Log.e("GOTO-E", "resource_url: " + resource_url);
+        Log.e("GOTO-D", "resource_url: " + resource_url);
         String cacheExpiredDate = versionTable.getCacheControlValue(update_key);
         String prevLastModified = versionTable.getVersionValue(update_key);
 
@@ -437,12 +438,12 @@ public class ResourceProcess {
                 if (!patchedFile.exists() || update_flag || patchVersion == null ||
                         !Objects.equals(versionTable.getVersionValue(patchFilePath), hash)) {
                     versionTable.putVersionValue(patchFilePath, hash);
-                    Log.e("GOTO", "needs repatch: " + patchedFilePath + " " + hash);
+                    Log.e("GOTO-D", "needs repatch: " + patchedFilePath + " " + hash);
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                         usePatchedCache = patchImage(out_file_path, patchedFilePath, patchFilePath);
                     }
                 } else {
-                    Log.e("GOTO", "using cached patched file: " + patchedFilePath + " " + hash);
+                    Log.e("GOTO-D", "using cached patched file: " + patchedFilePath + " " + hash);
                     usePatchedCache = true;
                 }
             }
@@ -978,7 +979,7 @@ public class ResourceProcess {
                 !Objects.equals(patchVersion, hash)) {
 
             versionTable.putVersionValue(patchFilePath, hash);
-            Log.e("GOTO", "needs repatch: " + patchedFilePath + " " + hash);
+            Log.e("GOTO-P", "needs repatch: " + patchedFilePath + " " + hash);
 
             try {
                 patchedFile.getParentFile().mkdirs();
@@ -1003,21 +1004,21 @@ public class ResourceProcess {
 
                         if (Arrays.equals(originalBytes, patchOriginalBytes)) {
                             KcUtils.copyFileUsingStream(patchedPatch, patchedFile);
-                            Log.e("GOTO", "patched via original/patched match: " + path);
+                            Log.e("GOTO-P", "patched via original/patched match: " + path);
                             usePatchedCache = true;
                         } else {
-                            Log.e("GOTO", "original mismatch, skipping patch: " + path);
+                            Log.e("GOTO-P", "original mismatch, skipping patch: " + path);
                         }
                     }
                 }
 
             } catch (IOException e) {
-                e.printStackTrace();
+                Log.e("GOTO-P", KcUtils.getStringFromException(e));
                 return originalFile;
             }
 
         } else {
-            Log.e("GOTO", "using cached patched file: " + patchedFilePath + " " + hash);
+            Log.e("GOTO-P", "using cached patched file: " + patchedFilePath + " " + hash);
             usePatchedCache = true;
         }
 
@@ -1025,28 +1026,32 @@ public class ResourceProcess {
     }
 
     public static boolean patchImage(String ogDestination, String ptDestination, String patchFile) {
-        if (ResourceProcess.isImage(ResourceProcess.getCurrentState(ptDestination))) {
-            Bitmap ogSpritesheet = BitmapFactory.decodeFile(ogDestination);
-            File metadataFile = new File(ogDestination.replace(".png", ".json"));
-            Log.e("GOTO-F", "patchImage-src: " + metadataFile.getAbsolutePath());
-            File dest = new File(ptDestination);
-            Log.e("GOTO-F", "patchImage-desc: " + metadataFile.getAbsolutePath());
-            if (!metadataFile.exists()) {
-                Bitmap ogImage = BitmapFactory.decodeFile(patchFile.concat("/original.png"));
-                if (ogSpritesheet != null && ogImage != null && KcEnUtils.bitmapEqual(ogSpritesheet, ogImage, 0.01f)) {
-                    File source = new File(patchFile.concat("/patched.png"));
-                    try {
+        try {
+            if (ResourceProcess.isImage(ResourceProcess.getCurrentState(ptDestination))) {
+                Bitmap ogSpritesheet = BitmapFactory.decodeFile(ogDestination);
+                File metadataFile = new File(getSpriteMetadataPath(ogDestination));
+                Log.e("GOTO-P", "patchImage-src: " + metadataFile.getAbsolutePath());
+                File dest = new File(ptDestination);
+                Log.e("GOTO-P", "patchImage-desc: " + metadataFile.getAbsolutePath());
+                if (!metadataFile.exists()) {
+                    Bitmap ogImage = BitmapFactory.decodeFile(patchFile.concat("/original.png"));
+                    Log.e("GOTO-P", patchFile.concat("/original.png"));
+                    if (ogSpritesheet != null && ogImage != null && KcEnUtils.bitmapEqual(ogSpritesheet, ogImage, 0.01f)) {
+                        File source = new File(patchFile.concat("/patched.png"));
                         dest.getParentFile().mkdirs();
                         dest.createNewFile();
                         KcUtils.copyFileUsingStream(source, dest);
-                        Log.e("GOTO", "image patched: " + ptDestination);
+                        Log.e("GOTO-P", "image patched: " + ptDestination);
                         return true;
-                    } catch (IOException e) {
-                        e.printStackTrace();
+                    } else {
+                        Log.e("GOTO-P", "image not patched: "
+                                + patchFile.concat("/original.png") + " "
+                                + (ogSpritesheet != null) + " "
+                                + (ogImage != null) + " "
+                                + KcEnUtils.bitmapEqual(ogSpritesheet, ogImage, 0.01f)
+                        );
                     }
-                }
-            } else {
-                try {
+                } else {
                     String ogFolder = "/original/";
                     String ptFolder = "/patched/";
                     boolean patchFound = false;
@@ -1080,12 +1085,22 @@ public class ResourceProcess {
                         }
                     }
                     return patchExported(dest, patchFound, ptSpritesheet);
-                } catch (IOException e) {
-                    e.printStackTrace();
                 }
             }
+        } catch (IOException e) {
+            Log.e("GOTO-P", KcUtils.getStringFromException(e));
         }
         return false;
+    }
+
+    private static String getSpriteMetadataPath(String path) {
+        if (path.endsWith(".jpg")) {
+            return path.replace(".jpg", ".json");
+        }
+        if (path.endsWith(".png")) {
+            return path.replace(".png", ".json");
+        }
+        return path + ".json";
     }
 
     private static Bitmap getPatchFolderSprite(String patchFile, String folder, Object originalFile) {

--- a/app/src/main/java/com/antest1/gotobrowser/Browser/ResourceProcess.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Browser/ResourceProcess.java
@@ -77,7 +77,7 @@ import static com.antest1.gotobrowser.Constants.PREF_CURSOR_MODE;
 import static com.antest1.gotobrowser.Constants.PREF_CURSOR_MODE_TOUCH;
 import static com.antest1.gotobrowser.Constants.PREF_DOWNLOAD_RETRY;
 import static com.antest1.gotobrowser.Constants.PREF_FONT_PREFETCH;
-import static com.antest1.gotobrowser.Constants.PREF_MOD_KANTAIEN;
+import static com.antest1.gotobrowser.Constants.PREF_MOD_KCCP_LANG_PATCH;
 import static com.antest1.gotobrowser.Constants.PREF_SILENT;
 import static com.antest1.gotobrowser.Constants.PREF_SUBTITLE_LOCALE;
 import static com.antest1.gotobrowser.Constants.REQUEST_BLOCK_RULES;
@@ -144,7 +144,7 @@ public class ResourceProcess {
         isCursorTouchMode = sharedPref.getString(PREF_CURSOR_MODE, PREF_CURSOR_MODE_TOUCH)
                 .equals(PREF_CURSOR_MODE_TOUCH);
         alterEndpoint = sharedPref.getString(PREF_ALTER_ENDPOINT, DEFAULT_ALTER_GADGET_URL);
-        prefModKantaiEn = sharedPref.getBoolean(PREF_MOD_KANTAIEN, false);
+        prefModKantaiEn = sharedPref.getBoolean(PREF_MOD_KCCP_LANG_PATCH, false);
         subtitleText = activity.findViewById(R.id.subtitle_view);
         subtitleText.setOnClickListener(v -> clearSubHandler.postDelayed(clearSubtitle, 250));
     }

--- a/app/src/main/java/com/antest1/gotobrowser/Constants.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Constants.java
@@ -36,7 +36,13 @@ public class Constants {
     public static final String PREF_TP_DISCLAIMED = "pref_tp_disclaimed";
     public static final String PREF_LEGACY_RENDERER = "pref_legacy_renderer";
     public static final String PREF_MOD_KANTAI3D = "pref_mod_kantai3d";
-    public static final String PREF_MOD_KANTAIEN = "pref_mod_kantaien";
+    public static final String PREF_MOD_KCCP_LANG_PATCH = "pref_mod_kccp_lang_patch";
+    public static final String PREF_MOD_KCCP_LANG_PATCH_NAME = "pref_mod_kccp_lang_patch_name";
+    public static final String PREF_MOD_KCCP_LANG_PATCH_GITHUB = "pref_github_kccp";
+    public static final String PREF_MOD_KCCP_LANG_PATCH_EN = "kccp_lang_en";
+    public static final String PREF_MOD_KCCP_LANG_PATCH_ID = "kccp_lang_id";
+
+    public static final String PREF_MOD_KANTAIEN_LEGACY = "pref_mod_kantaien";
     public static final String PREF_MOD_KANTAIID = "pref_mod_kantaiid";
     public static final String PREF_MOD_KANTAIEN_UPDATE = "pref_mod_kantaien_update";
     public static final String PREF_MOD_KANTAIEN_DELETE = "pref_mod_kantaien_delete";
@@ -65,7 +71,8 @@ public class Constants {
             PREF_SUBTITLE_LOCALE,
             PREF_LEGACY_RENDERER,
             PREF_MOD_KANTAI3D,
-            PREF_MOD_KANTAIEN,
+            PREF_MOD_KCCP_LANG_PATCH,
+            PREF_MOD_KCCP_LANG_PATCH_NAME,
             PREF_MOD_FPS,
             PREF_MOD_CRIT,
             PREF_DEVTOOLS_DEBUG,

--- a/app/src/main/java/com/antest1/gotobrowser/Constants.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Constants.java
@@ -43,7 +43,6 @@ public class Constants {
     public static final String PREF_MOD_KCCP_LANG_PATCH_ID = "kccp_lang_id";
 
     public static final String PREF_MOD_KANTAIEN_LEGACY = "pref_mod_kantaien";
-    public static final String PREF_MOD_KANTAIID = "pref_mod_kantaiid";
     public static final String PREF_MOD_KANTAIEN_UPDATE = "pref_mod_kantaien_update";
     public static final String PREF_MOD_KANTAIEN_DELETE = "pref_mod_kantaien_delete";
     public static final String PREF_MOD_FPS = "pref_mod_fps";

--- a/app/src/main/java/com/antest1/gotobrowser/Helpers/KcEnUtils.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Helpers/KcEnUtils.java
@@ -31,6 +31,7 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Objects;
@@ -109,7 +110,9 @@ public class KcEnUtils {
 
     }
 
-    public static void setPatchLanguage(KenPatcher.PatchLanguage language) {
+    public void setPatchLanguage(String preference) {
+        KenPatcher.PatchLanguage language =
+                KenPatcher.getCurrentPatchLanguage(preference);
         KenPatcher.setPatchLanguage(language);
     }
 
@@ -187,14 +190,14 @@ public class KcEnUtils {
                     }
 
                 } catch (IOException e) {
-                    e.printStackTrace();
+                    Log.e("GOTO", KcUtils.getStringFromException(e));
                     resultData.addProperty("error", getStringFromException(e));
                 }
                 return resultData;
             });
             enPatchInfo = result.get();
         } catch (Exception e) {
-            e.printStackTrace();
+            Log.e("GOTO", KcUtils.getStringFromException(e));
             enPatchInfo.addProperty("error", getStringFromException(e));
         }
         Log.e("GOTO", "enPatchInfo: " + enPatchInfo.toString());
@@ -218,13 +221,13 @@ public class KcEnUtils {
                         }
                     }
                 } catch (IOException e) {
-                    e.printStackTrace();
+                    Log.e("GOTO", KcUtils.getStringFromException(e));
                 }
                 return resultData;
             });
             enVersionInfo = result.get();
         } catch (Exception e) {
-            e.printStackTrace();
+            Log.e("GOTO", KcUtils.getStringFromException(e));
         }
         Log.e("GOTO", "enPatchInfo: " + enVersionInfo.toString());
         return enVersionInfo;
@@ -252,7 +255,7 @@ public class KcEnUtils {
             newVersionFlag = false;
         } else {
             enPatchLocalInfo = KcUtils.readJsonObjectFromFile(enPatchLocalInfoFile.getPath());
-            if (enPatchLocalInfo.has("version")) {
+            if (enPatchLocalInfo != null && enPatchLocalInfo.has("version")) {
                 currentVersion = enPatchLocalInfo.get("version").getAsString();
                 if (!currentVersion.equals(availableVersion)) {
                     kantaiEnUpdate.setSummary(String.format(Locale.US,
@@ -301,7 +304,7 @@ public class KcEnUtils {
             return (con.getResponseCode() == HttpURLConnection.HTTP_OK);
         }
         catch (Exception e) {
-            e.printStackTrace();
+            Log.e("GOTO", KcUtils.getStringFromException(e));
             return false;
         }
     }
@@ -353,9 +356,10 @@ public class KcEnUtils {
     public static Set<String> listFiles(String dir) {
         Set<String> files = new HashSet<>();
         File[] fileList = new File(dir).listFiles();
-
-        for (File f: fileList) {
-            if (!f.isDirectory()) files.add(f.getName());
+        if (fileList != null) {
+            for (File f: fileList) {
+                if (!f.isDirectory()) files.add(f.getName());
+            }
         }
         return files;
     }
@@ -439,8 +443,9 @@ public class KcEnUtils {
             for (byte md5Byte : md5Bytes) {
                 returnVal.append(Integer.toString((md5Byte & 0xff) + 0x100, 16).substring(1));
             }
+        } catch (NoSuchAlgorithmException | IOException e) {
+            Log.e("GOTO", KcUtils.getStringFromException(e));
         }
-        catch(Throwable t) {t.printStackTrace();}
         return returnVal.toString().toUpperCase();
     }
 
@@ -745,7 +750,7 @@ public class KcEnUtils {
                 try {
                     file.createNewFile();
                 } catch (IOException e) {
-                    e.printStackTrace();
+                    Log.e("GOTO", KcUtils.getStringFromException(e));
                     return -1;
                 }
                 Log.e("GOTO", "Created .nomedia file");
@@ -759,7 +764,7 @@ public class KcEnUtils {
                 boolean deleted = zipOut.delete();
                 return deleted ? 1 : 0;
             } catch (Exception e) {
-                e.printStackTrace();
+                Log.e("GOTO", KcUtils.getStringFromException(e));
                 return -1;
             }
         }
@@ -767,27 +772,29 @@ public class KcEnUtils {
         @Override
         protected void onPostExecute(Integer integer) {
             super.onPostExecute(integer);
-            if (integer == 1) {
-                Log.e("GOTO", "Zip was deleted");
-                KcUtils.showToast(context, R.string.en_install_done_notification);
-                if (fragment != null) {
-                    Preference kantaiEnUpdate = fragment.findPreference(PREF_MOD_KANTAIEN_UPDATE);
+
+            Preference kantaiEnUpdate = null;
+            if (fragment != null) kantaiEnUpdate =
+                    fragment.findPreference(PREF_MOD_KANTAIEN_UPDATE);
+
+            if (kantaiEnUpdate != null) {
+                if (integer == 1) {
+                    Log.e("GOTO", "Zip was deleted");
+                    KcUtils.showToast(context, R.string.en_install_done_notification);
                     kantaiEnUpdate.setSummary(fragment.getString(R.string.setting_latest_version));
                     kantaiEnUpdate.setEnabled(false);
-                }
-            } else if (integer == 0) {
-                Log.e("GOTO", "Zip wasn't deleted");
-                KcUtils.showToast(context, "Download successful but zip was not deleted");
-                if (fragment != null) {
-                    Preference kantaiEnUpdate = fragment.findPreference(PREF_MOD_KANTAIEN_UPDATE);
+                } else if (integer == 0) {
+                    Log.e("GOTO", "Zip wasn't deleted");
+                    KcUtils.showToast(context, "Download successful but zip was not deleted");
                     kantaiEnUpdate.setSummary(fragment.getString(R.string.setting_latest_version));
                     kantaiEnUpdate.setEnabled(false);
+                } else if (integer == -1) {
+                    Log.e("GOTO", "Error occurred while downloading");
+                    KcUtils.showToast(context, "Error occurred while downloading");
                 }
-            } else if (integer == -1) {
-                Log.e("GOTO", "Error occurred while downloading");
-                KcUtils.showToast(context, "Error occurred while downloading");
             }
-            mProgressDialog.dismiss();
+
+            if (mProgressDialog != null) mProgressDialog.dismiss();
         }
     }
 }

--- a/app/src/main/java/com/antest1/gotobrowser/Helpers/KenPatcher.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Helpers/KenPatcher.java
@@ -12,7 +12,7 @@ import com.google.gson.JsonParser;
 
 import com.google.gson.JsonSyntaxException;
 
-import static com.antest1.gotobrowser.Constants.PREF_MOD_KANTAIEN;
+import static com.antest1.gotobrowser.Constants.PREF_MOD_KCCP_LANG_PATCH;
 import static com.antest1.gotobrowser.Constants.PREF_MOD_KANTAIID;
 
 import java.io.File;
@@ -49,7 +49,7 @@ public class KenPatcher {
         // Require reopening the browser after switching the MOD on or off
         SharedPreferences sharedPref = activity.getSharedPreferences(
                 activity.getString(R.string.preference_key), Context.MODE_PRIVATE);
-        patchLanguage = sharedPref.getBoolean(PREF_MOD_KANTAIEN, false) ? PatchLanguage.EN :
+        patchLanguage = sharedPref.getBoolean(PREF_MOD_KCCP_LANG_PATCH, false) ? PatchLanguage.EN :
                 sharedPref.getBoolean(PREF_MOD_KANTAIID, false) ? PatchLanguage.ID :
                         PatchLanguage.NONE;
     }

--- a/app/src/main/java/com/antest1/gotobrowser/Helpers/KenPatcher.java
+++ b/app/src/main/java/com/antest1/gotobrowser/Helpers/KenPatcher.java
@@ -12,8 +12,9 @@ import com.google.gson.JsonParser;
 
 import com.google.gson.JsonSyntaxException;
 
-import static com.antest1.gotobrowser.Constants.PREF_MOD_KCCP_LANG_PATCH;
-import static com.antest1.gotobrowser.Constants.PREF_MOD_KANTAIID;
+import static com.antest1.gotobrowser.Constants.PREF_MOD_KCCP_LANG_PATCH_EN;
+import static com.antest1.gotobrowser.Constants.PREF_MOD_KCCP_LANG_PATCH_ID;
+import static com.antest1.gotobrowser.Constants.PREF_MOD_KCCP_LANG_PATCH_NAME;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -44,14 +45,24 @@ public class KenPatcher {
         patchLanguage = language;
     }
 
+    public static PatchLanguage getCurrentPatchLanguage(String pref) {
+        if (PREF_MOD_KCCP_LANG_PATCH_EN.equals(pref)) {
+            return PatchLanguage.EN;
+        } else if (PREF_MOD_KCCP_LANG_PATCH_ID.equals(pref)) {
+            return PatchLanguage.ID;
+        } else { // fallback
+            return PatchLanguage.EN;
+        }
+    }
+
     public void prepare(Activity activity) {
         // Only update the enable status when opening the browser view
         // Require reopening the browser after switching the MOD on or off
         SharedPreferences sharedPref = activity.getSharedPreferences(
                 activity.getString(R.string.preference_key), Context.MODE_PRIVATE);
-        patchLanguage = sharedPref.getBoolean(PREF_MOD_KCCP_LANG_PATCH, false) ? PatchLanguage.EN :
-                sharedPref.getBoolean(PREF_MOD_KANTAIID, false) ? PatchLanguage.ID :
-                        PatchLanguage.NONE;
+        patchLanguage = getCurrentPatchLanguage(
+                sharedPref.getString(PREF_MOD_KCCP_LANG_PATCH_NAME, "")
+        );
     }
 
     public static String patchKantaiEn(String main_js, Activity activity) {
@@ -236,7 +247,7 @@ public class KenPatcher {
             return new JsonParser().parse(new String(buffer, "UTF-8"));
 
         } catch (IOException | JsonSyntaxException ex) {
-            ex.printStackTrace();
+            Log.e("GOTO", KcUtils.getStringFromException(ex));
         }
         return null;
     }
@@ -250,7 +261,7 @@ public class KenPatcher {
             stream.close();
             return new String(buffer, "UTF-8");
         } catch (IOException ex) {
-            ex.printStackTrace();
+            Log.e("GOTO", KcUtils.getStringFromException(ex));
         }
         return null;
     }

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -80,12 +80,19 @@
     <string name="settings_mod_kantai3d_summary">一部の秘書艦に3Dのような視覚効果とおける乳揺れを追加します。作者：@laplamgor</string>
     <string name="settings_mod_kantai3d_about">About Kantai3D</string>
     <string name="settings_mod_kantaien_enable">KanColle English Patch</string>
-    <string name="settings_mod_kantaien_summary">ゲームを英語に翻訳する。作者：@Oradimi</string>
-    <string name="settings_mod_kantaien_download">Patchデータダウンロード</string>
+    <string name="settings_mod_kantaien_download">パッチデータダウンロード</string>
     <string name="settings_mod_kantaien_download_start">ダウンロード中… アプリケーションをバックグラウンドにしたままにしておくことができます。</string>
-    <string name="settings_mod_kantaien_delete">Patchデータ削除</string>
+    <string name="settings_mod_kantaien_delete">パッチデータ削除</string>
     <string name="settings_mod_kantaien_delete_summary">パッチが予期しない動作を示している場合、またはダウンロード中に問題が発生した場合は、この設定を使用します。</string>
     <string name="settings_mod_kantaien_about">KanColle English Patchについて</string>
+    <string name="settings_mod_kantaiid_about">KanColle Indonesia Patchについて</string>
+
+    <string name="settings_mod_kccp">KanColle Language Patch (KCCP)</string>
+    <string name="settings_mod_kccp_summary">ゲーム内のテキストを他の言語に翻訳する</string>
+    <string name="settings_mod_kccp_patch_name">適用する言語パッチ</string>
+    <string name="settings_mod_kccp_patch_en_summary">KanColle English Patch (作者: @Oradimi)</string>
+    <string name="settings_mod_kccp_patch_id_summary">KanColle Indonesia Patch (作者: @SLAVUSworks)</string>
+
     <string name="settings_mod_fps_enable">60FPS制限を削除します</string>
     <string name="settings_mod_fps_summary">高リフレッシュ・レート対応。ゲームの速度は影響を受けません。</string>
     <string name="settings_mod_crit_enable">真のクリティカルヒット</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -81,12 +81,19 @@
     <string name="settings_mod_kantai3d_summary">일부 비서함에 3D 효과 적용. 저자: @laplamgor</string>
     <string name="settings_mod_kantai3d_about">About Kantai3D</string>
     <string name="settings_mod_kantaien_enable">KanColle English Patch</string>
-    <string name="settings_mod_kantaien_summary">게임 내 텍스트를 영어로 번역합니다. 저자: @Oradimi</string>
-    <string name="settings_mod_kantaien_download">Patch 데이터 다운로드</string>
+    <string name="settings_mod_kantaien_download">패치 데이터 다운로드</string>
     <string name="settings_mod_kantaien_download_start">다운로드 중… 다운로드하는 동안 애플리케이션을 백그라운드에 그대로 둘 수 있습니다.</string>
-    <string name="settings_mod_kantaien_delete">Patch 데이터 삭제</string>
+    <string name="settings_mod_kantaien_delete">패치 데이터 삭제</string>
     <string name="settings_mod_kantaien_delete_summary">패치가 예기치 않은 동작을 나타내거나 다운로드 중에 문제가 발생한 경우 이 설정을 사용하세요.</string>
     <string name="settings_mod_kantaien_about">KanColle English Patch에 대해</string>
+    <string name="settings_mod_kantaiid_about">KanColle Indonesia Patch에 대해</string>
+
+    <string name="settings_mod_kccp">KanColle Language Patch (KCCP)</string>
+    <string name="settings_mod_kccp_summary">게임 내 텍스트를 다른 언어로 번역</string>
+    <string name="settings_mod_kccp_patch_name">적용할 언어 패치</string>
+    <string name="settings_mod_kccp_patch_en_summary">KanColle English Patch (저자: @Oradimi)</string>
+    <string name="settings_mod_kccp_patch_id_summary">KanColle Indonesia Patch (저자: @SLAVUSworks)</string>
+
     <string name="settings_mod_fps_enable">60FPS 제한 제거</string>
     <string name="settings_mod_fps_summary">더 높은 화면 재생 빈도 장치를 지원합니다. 애니메이션 속도는 영향을 받지 않습니다.</string>
     <string name="settings_mod_crit_enable">진정한 크리티컬 히트</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -79,12 +79,19 @@
     <string name="settings_mod_kantai3d_summary">为部份秘书舰添加仿立体以及乳摇视觉效果。作者：@laplamgor</string>
     <string name="settings_mod_kantai3d_about">关于Kantai3D</string>
     <string name="settings_mod_kantaien_enable">KanColle English Patch</string>
-    <string name="settings_mod_kantaien_summary">将游戏界面翻译成英文。作者：@Oradimi</string>
-    <string name="settings_mod_kantaien_download">下载Patch资料</string>
+    <string name="settings_mod_kantaien_download">下载补丁资料</string>
     <string name="settings_mod_kantaien_download_start">正在下载… 您可以在下载时将应用程式留在背景。</string>
-    <string name="settings_mod_kantaien_delete">删除Patch资料</string>
+    <string name="settings_mod_kantaien_delete">删除补丁资料</string>
     <string name="settings_mod_kantaien_delete_summary">如果修补程式出现预期外行为，或者在下载过程中出现问题，请使用此设定。</string>
     <string name="settings_mod_kantaien_about">KanColle English Patch关于</string>
+    <string name="settings_mod_kantaiid_about">KanColle Indonesia Patch关于</string>
+
+    <string name="settings_mod_kccp">KanColle Language Patch (KCCP)</string>
+    <string name="settings_mod_kccp_summary">将游戏界面翻译成其他语言</string>
+    <string name="settings_mod_kccp_patch_name">要使用的补丁</string>
+    <string name="settings_mod_kccp_patch_en_summary">KanColle English Patch (作者: @Oradimi)</string>
+    <string name="settings_mod_kccp_patch_id_summary">KanColle Indonesia Patch (作者: @SLAVUSworks)</string>
+
     <string name="settings_mod_fps_enable">移除60帧限制</string>
     <string name="settings_mod_fps_summary">支援高萤幕更新率手机，不会影响游戏动画速度。</string>
     <string name="settings_mod_crit_enable">真正的Critical hit</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -79,12 +79,19 @@
     <string name="settings_mod_kantai3d_summary">為部份秘書艦添加仿立體以及乳搖視覺效果。作者：@laplamgor</string>
     <string name="settings_mod_kantai3d_about">關於Kantai3D</string>
     <string name="settings_mod_kantaien_enable">KanColle English Patch</string>
-    <string name="settings_mod_kantaien_summary">將遊戲界面翻譯成英文。作者：@Oradimi</string>
-    <string name="settings_mod_kantaien_download">下載Patch資料</string>
+    <string name="settings_mod_kantaien_download">下載補丁資料</string>
     <string name="settings_mod_kantaien_download_start">正在下載… 您可以在下載時將應用程式留在背景。</string>
-    <string name="settings_mod_kantaien_delete">刪除Patch資料</string>
+    <string name="settings_mod_kantaien_delete">刪除補丁資料</string>
     <string name="settings_mod_kantaien_delete_summary">如果修補程式出現預期外行為，或者在下載過程中出現問題，請使用此設定。</string>
     <string name="settings_mod_kantaien_about">KanColle English Patch關於</string>
+    <string name="settings_mod_kantaiid_about">KanColle Indonesia Patch關於</string>
+
+    <string name="settings_mod_kccp">KanColle Language Patch (KCCP)</string>
+    <string name="settings_mod_kccp_summary">將遊戲界面翻譯成其他語言</string>
+    <string name="settings_mod_kccp_patch_name">要使用的補丁</string>
+    <string name="settings_mod_kccp_patch_en_summary">KanColle English Patch (作者: @Oradimi)</string>
+    <string name="settings_mod_kccp_patch_id_summary">KanColle Indonesian Patch (作者: @SLAVUSworks)</string>
+
     <string name="settings_mod_fps_enable">移除60幀限制</string>
     <string name="settings_mod_fps_summary">支援高螢幕更新率手機，不會影響遊戲動畫速度。</string>
     <string name="settings_mod_crit_enable">真正的Critical hit</string>

--- a/app/src/main/res/values-zh-rMO/strings.xml
+++ b/app/src/main/res/values-zh-rMO/strings.xml
@@ -79,12 +79,19 @@
     <string name="settings_mod_kantai3d_summary">為部份秘書艦添加仿立體以及乳搖視覺效果。作者：@laplamgor</string>
     <string name="settings_mod_kantai3d_about">關於Kantai3D</string>
     <string name="settings_mod_kantaien_enable">KanColle English Patch</string>
-    <string name="settings_mod_kantaien_summary">將遊戲界面翻譯成英文。作者：@Oradimi</string>
-    <string name="settings_mod_kantaien_download">下載Patch資料</string>
+    <string name="settings_mod_kantaien_download">下載補丁資料</string>
     <string name="settings_mod_kantaien_download_start">正在下載… 您可以在下載時將應用程式留在背景。</string>
-    <string name="settings_mod_kantaien_delete">刪除Patch資料</string>
+    <string name="settings_mod_kantaien_delete">刪除補丁資料</string>
     <string name="settings_mod_kantaien_delete_summary">如果修補程式出現預期外行為，或者在下載過程中出現問題，請使用此設定。</string>
     <string name="settings_mod_kantaien_about">KanColle English Patch關於</string>
+    <string name="settings_mod_kantaiid_about">KanColle Indonesia Patch關於</string>
+
+    <string name="settings_mod_kccp">KanColle Language Patch (KCCP)</string>
+    <string name="settings_mod_kccp_summary">將遊戲界面翻譯成其他語言</string>
+    <string name="settings_mod_kccp_patch_name">要使用的補丁</string>
+    <string name="settings_mod_kccp_patch_en_summary">KanColle English Patch (作者: @Oradimi)</string>
+    <string name="settings_mod_kccp_patch_id_summary">KanColle Indonesian Patch (作者: @SLAVUSworks)</string>
+
     <string name="settings_mod_fps_enable">移除60幀限制</string>
     <string name="settings_mod_fps_summary">支援高螢幕更新率手機，不會影響遊戲動畫速度。</string>
     <string name="settings_mod_crit_enable">真正的Critical hit</string>

--- a/app/src/main/res/values-zh-rSG/strings.xml
+++ b/app/src/main/res/values-zh-rSG/strings.xml
@@ -79,12 +79,19 @@
     <string name="settings_mod_kantai3d_summary">为部份秘书舰添加仿立体以及乳摇视觉效果。作者：@laplamgor</string>
     <string name="settings_mod_kantai3d_about">关于Kantai3D</string>
     <string name="settings_mod_kantaien_enable">[Beta] KanColle English Patch</string>
-    <string name="settings_mod_kantaien_summary">将游戏界面翻译成英文。作者：@Oradimi</string>
-    <string name="settings_mod_kantaien_download">下载Patch资料</string>
+    <string name="settings_mod_kantaien_download">下载L補丁资料</string>
     <string name="settings_mod_kantaien_download_start">正在下载… 您可以在下载时将应用程式留在背景。</string>
-    <string name="settings_mod_kantaien_delete">删除Patch资料</string>
+    <string name="settings_mod_kantaien_delete">删除補丁资料</string>
     <string name="settings_mod_kantaien_delete_summary">如果修补程式出现预期外行为，或者在下载过程中出现问题，请使用此设定。</string>
     <string name="settings_mod_kantaien_about">KanColle English Patch关于</string>
+    <string name="settings_mod_kantaiid_about">KanColle Indonesia Patch关于</string>
+
+    <string name="settings_mod_kccp">KanColle Language Patch (KCCP)</string>
+    <string name="settings_mod_kccp_summary">将游戏界面翻译成其他语言</string>
+    <string name="settings_mod_kccp_patch_name">要使用的補丁</string>
+    <string name="settings_mod_kccp_patch_en_summary">KanColle English Patch (作者: @Oradimi)</string>
+    <string name="settings_mod_kccp_patch_id_summary">KanColle Indonesia Patch (作者: @SLAVUSworks)</string>
+
     <string name="settings_mod_fps_enable">移除60帧限制</string>
     <string name="settings_mod_fps_summary">支援高萤幕更新率手机，不会影响游戏动画速度。</string>
     <string name="settings_mod_crit_enable">真正的Critical hit</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -79,12 +79,19 @@
     <string name="settings_mod_kantai3d_summary">為部份秘書艦添加仿立體以及乳搖視覺效果。作者：@laplamgor</string>
     <string name="settings_mod_kantai3d_about">關於Kantai3D</string>
     <string name="settings_mod_kantaien_enable">KanColle English Patch</string>
-    <string name="settings_mod_kantaien_summary">將遊戲界面翻譯成英文。作者：@Oradimi</string>
-    <string name="settings_mod_kantaien_download">下載Patch資料</string>
+    <string name="settings_mod_kantaien_download">下載補丁資料</string>
     <string name="settings_mod_kantaien_download_start">正在下載… 您可以在下載時將應用程式留在背景。</string>
-    <string name="settings_mod_kantaien_delete">刪除Patch資料</string>
+    <string name="settings_mod_kantaien_delete">刪除補丁資料</string>
     <string name="settings_mod_kantaien_delete_summary">如果修補程式出現預期外行為，或者在下載過程中出現問題，請使用此設定。</string>
     <string name="settings_mod_kantaien_about">KanColle English Patch關於</string>
+    <string name="settings_mod_kantaiid_about">KanColle Indonesia Patch關於</string>
+
+    <string name="settings_mod_kccp">KanColle Language Patch (KCCP)</string>
+    <string name="settings_mod_kccp_summary">將遊戲界面翻譯成其他語言</string>
+    <string name="settings_mod_kccp_patch_name">要使用的補丁</string>
+    <string name="settings_mod_kccp_patch_en_summary">KanColle English Patch (作者: @Oradimi)</string>
+    <string name="settings_mod_kccp_patch_id_summary">KanColle Indonesian Patch (作者: @SLAVUSworks)</string>
+
     <string name="settings_mod_fps_enable">移除60幀限制</string>
     <string name="settings_mod_fps_summary">支援高螢幕更新率手機，不會影響遊戲動畫速度。</string>
     <string name="settings_mod_crit_enable">真正的Critical hit</string>

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -44,7 +44,7 @@
 
     <string-array name="kccp_language" translatable="false">
         <item>KanColle English Patch</item>
-        <item>KanColle Indoneisia Patch</item>
+        <item>KanColle Indonesia Patch</item>
     </string-array>
 
     <string-array name="kccp_language_values" translatable="false">

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -41,4 +41,14 @@
         <item>kancolle.moe</item>
         <item>ooi.moe</item>
     </string-array>
+
+    <string-array name="kccp_language" translatable="false">
+        <item>KanColle English Patch</item>
+        <item>KanColle Indoneisia Patch</item>
+    </string-array>
+
+    <string-array name="kccp_language_values" translatable="false">
+        <item>kccp_lang_en</item>
+        <item>kccp_lang_id</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -89,15 +89,21 @@
     <string name="settings_mod_kantai3d_summary">Add 3D-like visual effects and jiggle physics to some of your secretaries. Author: @laplamgor</string>
     <string name="settings_mod_kantai3d_about">About Kantai3D</string>
     <string name="settings_mod_kantaien_enable">KanColle English Patch</string>
-    <string name="settings_mod_kantaien_summary">Translates most of the game into English. Author: @Oradimi</string>
-    <string name="settings_mod_kantaiid_enable">KanColle Indonesia Patch</string>
-    <string name="settings_mod_kantaiid_summary">Translates most of the game into Indonesian. Author: @SLAVUSworks</string>
     <string name="settings_mod_kantaien_download">Download Patch Data</string>
     <string name="settings_mod_kantaien_download_start">Downloading… You can leave the application in the background while downloading.</string>
     <string name="settings_mod_kantaien_delete">Delete Patch Data</string>
     <string name="settings_mod_kantaien_delete_summary">Use this setting if the patch is presenting unexpected behaviour, or if something went wrong during download.</string>
     <string name="settings_mod_kantaien_about">About KanColle English Patch</string>
     <string name="settings_mod_kantaiid_about">About KanColle Indonesia Patch</string>
+
+    <string name="settings_mod_kccp">KanColle Language Patch (KCCP)</string>
+    <string name="settings_mod_kccp_summary">Translate in-game text into other languages</string>
+    <string name="settings_mod_kccp_patch_name">Language Patch to Apply</string>
+    <string name="settings_mod_kccp_patch_en_summary">KanColle English Patch (Author: @Oradimi)</string>
+    <string name="settings_mod_kccp_patch_id_summary">KanColle Indonesia Patch (Author: @SLAVUSworks)</string>
+    <string name="settings_mod_kccp_patch_en_link" formatted="false" translatable="false">https://github.com/Oradimi/KanColle-English-Patch-KCCP</string>
+    <string name="settings_mod_kccp_patch_id_link" formatted="false" translatable="false">https://github.com/SLAVUSworks/KanColle-Indonesia-Patch-KCCP</string>
+
     <string name="settings_mod_fps_enable">Remove 60 FPS limit</string>
     <string name="settings_mod_fps_summary">Support higher refresh rate devices. Animation speed is not affected.</string>
     <string name="settings_mod_crit_enable">True Critical Hits</string>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -160,48 +160,41 @@
             app:title="@string/settings_mod_crit_enable" />
 
         <SwitchPreferenceCompat
-            android:summary="@string/settings_mod_kantaien_summary"
+            android:summary="@string/settings_mod_kccp_summary"
             app:iconSpaceReserved="false"
-            app:key="pref_mod_kantaien"
-            app:title="@string/settings_mod_kantaien_enable" />
+            app:key="pref_mod_kccp_lang_patch"
+            app:title="@string/settings_mod_kccp" />
+
+        <ListPreference
+            android:dependency="pref_mod_kccp_lang_patch"
+            app:iconSpaceReserved="false"
+            app:defaultValue="kccp_lang_en"
+            app:key="pref_mod_kccp_lang_patch_name"
+            app:title="@string/settings_mod_kccp_patch_name"
+            app:entries="@array/kccp_language"
+            app:entryValues="@array/kccp_language_values" />
 
         <Preference
-            app:iconSpaceReserved="false"
-            app:key="pref_github_kccp"
-            app:title="@string/settings_mod_kantaien_about"
-            app:summary="https://github.com/Oradimi/KanColle-English-Patch-KCCP">
-            <intent
-                android:action="android.intent.action.VIEW"
-                android:data="https://github.com/Oradimi/KanColle-English-Patch-KCCP"/>
-        </Preference>
-
-        <SwitchPreferenceCompat
-            android:summary="@string/settings_mod_kantaiid_summary"
-            app:iconSpaceReserved="false"
-            app:key="pref_mod_kantaiid"
-            app:title="@string/settings_mod_kantaiid_enable" />
-
-        <Preference
-            app:iconSpaceReserved="false"
-            app:key="pref_github_kccp_id"
-            app:title="@string/settings_mod_kantaiid_about"
-            app:summary="https://github.com/SLAVUSworks/KanColle-Indonesia-Patch-KCCP">
-            <intent
-                android:action="android.intent.action.VIEW"
-                android:data="https://github.com/SLAVUSworks/KanColle-Indonesia-Patch-KCCP"/>
-        </Preference>
-
-        <Preference
+            android:dependency="pref_mod_kccp_lang_patch"
             app:iconSpaceReserved="false"
             app:key="pref_mod_kantaien_update"
             app:title="@string/settings_mod_kantaien_download"
             app:summary="checking updates..." />
 
         <Preference
+            android:dependency="pref_mod_kccp_lang_patch"
             app:iconSpaceReserved="false"
             app:key="pref_mod_kantaien_delete"
             app:title="@string/settings_mod_kantaien_delete"
             app:summary="@string/settings_mod_kantaien_delete_summary" />
+
+        <Preference
+            android:layout_width="wrap_content"
+            android:dependency="pref_mod_kccp_lang_patch"
+            app:iconSpaceReserved="false"
+            app:key="pref_github_kccp"
+            app:summary="@string/settings_mod_kccp_patch_en_link"
+            app:title="@string/settings_mod_kantaien_about"></Preference>
 
     </PreferenceCategory>
 


### PR DESCRIPTION
## Updates 

- Updated existing preference to apply the patch regardless of the language setting (see screenshot below).
- Add a list preference to select which patch to use (EN/ID).
  - Downloading/deleting patch data now works based on this setting.
- Add preference translations for jp/ko.
- Fix a bug where Indonesian patch data could not be downloaded in settings.

<img width="800"  alt="image" src="https://github.com/user-attachments/assets/b2824bc0-4942-4163-860b-8a79637cc2a3" />

---

@Oradimi I’ve confirmed that the patch-related feature is working correctly, but I’d like to ask you to verify once more that it is functioning as intended.